### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3-alpine
+LABEL org.opencontainers.image.source github.com/akpw/mktxp
+WORKDIR /mktxp
+COPY . .
+RUN pip install ./
+EXPOSE 49090
+ENTRYPOINT ["/usr/local/bin/mktxp"]
+CMD ["export"]


### PR DESCRIPTION
#3 appears stalled.  This PR creates the docker container on top of an alpine image which results in a smaller overall image size.

As an aside due to the way config loading appears to work its necessary to mount mktxp.conf at /root/mktxp/mktxp.conf, if there's a search path for where that config is read from it would be good to document it.