### PR TITLE
adapt health datasource to RouterOS v7

### DIFF
--- a/mktxp/cli/config/config.py
+++ b/mktxp/cli/config/config.py
@@ -39,6 +39,7 @@ class MKTXPConfigKeys:
     FE_DHCP_KEY = 'dhcp'
     FE_DHCP_LEASE_KEY = 'dhcp_lease'    
     FE_DHCP_POOL_KEY = 'pool'    
+    FE_IP_CONNECTIONS_KEY = 'connections'    
     FE_INTERFACE_KEY = 'interface'
     FE_FIREWALL_KEY = 'firewall'
     FE_MONITOR_KEY = 'monitor'
@@ -81,7 +82,7 @@ class MKTXPConfigKeys:
     BOOLEAN_KEYS_NO = {ENABLED_KEY, SSL_KEY, NO_SSL_CERTIFICATE, SSL_CERTIFICATE_VERIFY}
     
     # Feature keys enabled by default
-    BOOLEAN_KEYS_YES = {FE_DHCP_KEY, FE_DHCP_LEASE_KEY, FE_DHCP_POOL_KEY, FE_INTERFACE_KEY, FE_FIREWALL_KEY,
+    BOOLEAN_KEYS_YES = {FE_DHCP_KEY, FE_DHCP_LEASE_KEY, FE_DHCP_POOL_KEY, FE_IP_CONNECTIONS_KEY, FE_INTERFACE_KEY, FE_FIREWALL_KEY,
                       FE_MONITOR_KEY, FE_ROUTE_KEY, MKTXP_USE_COMMENTS_OVER_NAMES, 
                       FE_WIRELESS_KEY, FE_WIRELESS_CLIENTS_KEY, FE_CAPSMAN_KEY, FE_CAPSMAN_CLIENTS_KEY, FE_POE_KEY, FE_NETWATCH_KEY}
 
@@ -100,7 +101,7 @@ class ConfigEntry:
                                                  MKTXPConfigKeys.SSL_KEY, MKTXPConfigKeys.NO_SSL_CERTIFICATE, MKTXPConfigKeys.SSL_CERTIFICATE_VERIFY,
 
                                                  MKTXPConfigKeys.FE_DHCP_KEY, MKTXPConfigKeys.FE_DHCP_LEASE_KEY, MKTXPConfigKeys.FE_DHCP_POOL_KEY, MKTXPConfigKeys.FE_INTERFACE_KEY, MKTXPConfigKeys.FE_FIREWALL_KEY,
-                                                 MKTXPConfigKeys.FE_MONITOR_KEY, MKTXPConfigKeys.FE_ROUTE_KEY, MKTXPConfigKeys.FE_WIRELESS_KEY, MKTXPConfigKeys.FE_WIRELESS_CLIENTS_KEY,
+                                                 MKTXPConfigKeys.FE_MONITOR_KEY, MKTXPConfigKeys.FE_ROUTE_KEY, MKTXPConfigKeys.FE_WIRELESS_KEY, MKTXPConfigKeys.FE_WIRELESS_CLIENTS_KEY, MKTXPConfigKeys.FE_IP_CONNECTIONS_KEY,
                                                  MKTXPConfigKeys.FE_CAPSMAN_KEY, MKTXPConfigKeys.FE_CAPSMAN_CLIENTS_KEY, MKTXPConfigKeys.FE_POE_KEY, MKTXPConfigKeys.FE_NETWATCH_KEY, MKTXPConfigKeys.MKTXP_USE_COMMENTS_OVER_NAMES
                                                  ])
     MKTXPSystemEntry = namedtuple('MKTXPSystemEntry', [MKTXPConfigKeys.PORT_KEY, MKTXPConfigKeys.MKTXP_SOCKET_TIMEOUT,

--- a/mktxp/cli/config/mktxp.conf
+++ b/mktxp/cli/config/mktxp.conf
@@ -26,6 +26,7 @@
 
     dhcp = True                     # DHCP general metrics
     dhcp_lease = True               # DHCP lease metrics
+    connections = True              # IP connections metrics
     pool = True                     # Pool metrics
     interface = True                # Interfaces traffic metrics
     firewall = True                 # Firewall rules traffic metrics

--- a/mktxp/collector/connection_collector.py
+++ b/mktxp/collector/connection_collector.py
@@ -1,0 +1,31 @@
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+
+from mktxp.collector.base_collector import BaseCollector
+from mktxp.datasource.connection_ds import IPConnectionDatasource
+
+
+class IPConnectionCollector(BaseCollector):
+    ''' IP Connection Metrics collector
+    '''    
+    @staticmethod
+    def collect(router_entry):
+        if not router_entry.config_entry.connections:
+           return
+           
+        connection_records = IPConnectionDatasource.metric_records(router_entry, metric_labels = [])
+        if connection_records:
+
+            connection_metrics = BaseCollector.gauge_collector('ip_connections_total', 'Number of IP connections', connection_records, 'count',)
+            yield connection_metrics

--- a/mktxp/collector/health_collector.py
+++ b/mktxp/collector/health_collector.py
@@ -24,17 +24,24 @@ class HealthCollector(BaseCollector):
         health_labels = ['voltage', 'temperature', 'cpu_temperature', 'fan1_speed', 'fan2_speed']
         health_records = HealthMetricsDataSource.metric_records(router_entry, metric_labels = health_labels)   
         if health_records:
-            voltage_metrics = BaseCollector.gauge_collector('system_routerboard_voltage', 'Supplied routerboard voltage', health_records, 'voltage')
-            yield voltage_metrics
+            for record in health_records:
 
-            temperature_metrics = BaseCollector.gauge_collector('system_routerboard_temperature', 'Routerboard current temperature', health_records, 'temperature')
-            yield temperature_metrics
+                if 'voltage' in record:
+                    voltage_metrics = BaseCollector.gauge_collector('system_routerboard_voltage', 'Supplied routerboard voltage', [record, ], 'voltage')
+                    yield voltage_metrics
 
-            cpu_temperature_metrics = BaseCollector.gauge_collector('system_cpu_temperature', 'CPU current temperature', health_records, 'cpu_temperature')
-            yield cpu_temperature_metrics
+                if 'temperature' in record:
+                    temperature_metrics = BaseCollector.gauge_collector('system_routerboard_temperature', 'Routerboard current temperature', [record, ], 'temperature')
+                    yield temperature_metrics
 
-            fan_one_speed_metrics = BaseCollector.gauge_collector('system_fan_one_speed', 'System fan 1 current speed', health_records, 'fan1_speed')
-            yield fan_one_speed_metrics
+                if 'cpu_temperature' in record:
+                    cpu_temperature_metrics = BaseCollector.gauge_collector('system_cpu_temperature', 'CPU current temperature', [record, ], 'cpu_temperature')
+                    yield cpu_temperature_metrics
 
-            fan_two_speed_metrics = BaseCollector.gauge_collector('system_fan_two_speed', 'System fan 2 current speed', health_records, 'fan2_speed')
-            yield fan_two_speed_metrics
+                if 'fan1_speed' in record:
+                    fan_one_speed_metrics = BaseCollector.gauge_collector('system_fan_one_speed', 'System fan 1 current speed', [record, ], 'fan1_speed')
+                    yield fan_one_speed_metrics
+
+                if 'fan2_speed' in record:
+                    fan_two_speed_metrics = BaseCollector.gauge_collector('system_fan_two_speed', 'System fan 2 current speed', [record, ], 'fan2_speed')
+                    yield fan_two_speed_metrics

--- a/mktxp/datasource/connection_ds.py
+++ b/mktxp/datasource/connection_ds.py
@@ -1,0 +1,33 @@
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+
+from mktxp.datasource.base_ds import BaseDSProcessor
+
+
+class IPConnectionDatasource:
+    ''' IP connections data provider
+    '''             
+    @staticmethod
+    def metric_records(router_entry, *, metric_labels = []):
+        try:
+            answer = router_entry.api_connection.router_api().get_binary_resource('/ip/firewall/connection/').call('print', {'count-only': b''})
+            # answer looks and feels like an empty list: [], but it has a special attribute `done_message`
+            done_message = answer.done_message
+            # `done_msg` is a dict with the return code as a key - which is the count that we are looking for
+            cnt = done_message['ret'].decode()
+            records = [{'count': cnt}]
+            return BaseDSProcessor.trimmed_records(router_entry, router_records = records, metric_labels = metric_labels)
+        except Exception as exc:
+            print(f'Error getting IP connection info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
+            return None

--- a/mktxp/datasource/health_ds.py
+++ b/mktxp/datasource/health_ds.py
@@ -22,7 +22,6 @@ class HealthMetricsDataSource:
     def metric_records(router_entry, *, metric_labels = []):
         try:
             health_records = router_entry.api_connection.router_api().get_resource('/system/health').get()
-
             for record in health_records:
                 if 'name' in record:
                     # Note: The API in RouterOS v7.X+ returns a response like this:

--- a/mktxp/datasource/health_ds.py
+++ b/mktxp/datasource/health_ds.py
@@ -22,6 +22,17 @@ class HealthMetricsDataSource:
     def metric_records(router_entry, *, metric_labels = []):
         try:
             health_records = router_entry.api_connection.router_api().get_resource('/system/health').get()
+
+            for record in health_records:
+                if 'name' in record:
+                    # Note: The API in RouterOS v7.X+ returns a response like this:
+                    # [{'name': 'temperature', 'value': '33', 'type': 'C'}, ...]
+                    # To make this work for both v6 and v7 add a <name>:<value> pair in v7
+                    # Otherwise it is not possible to get the value by name (e.g. records['voltage'])
+                    name = record['name']
+                    val = record.get('value', None)
+                    record[name] = val
+
             return BaseDSProcessor.trimmed_records(router_entry, router_records = health_records, metric_labels = metric_labels)
         except Exception as exc:
             print(f'Error getting system health info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')

--- a/mktxp/flow/collector_registry.py
+++ b/mktxp/flow/collector_registry.py
@@ -13,8 +13,8 @@
 
 
 from collections import OrderedDict
-from mktxp.cli.config.config import MKTXPConfigKeys
 from mktxp.collector.dhcp_collector import DHCPCollector
+from mktxp.collector.connection_collector import IPConnectionCollector
 from mktxp.collector.interface_collector import InterfaceCollector
 from mktxp.collector.health_collector import HealthCollector
 from mktxp.collector.identity_collector import IdentityCollector
@@ -45,6 +45,7 @@ class CollectorRegistry:
         self.register('HealthCollector', HealthCollector.collect)
 
         self.register('DHCPCollector', DHCPCollector.collect)
+        self.register('IPConnectionCollector', IPConnectionCollector.collect)
         self.register('PoolCollector', PoolCollector.collect)
         self.register('InterfaceCollector', InterfaceCollector.collect)
 

--- a/mktxp/flow/router_entry.py
+++ b/mktxp/flow/router_entry.py
@@ -32,6 +32,7 @@ class RouterEntry:
                             'HealthCollector': 0,
                             'DHCPCollector': 0,
                             'PoolCollector': 0,
+                            'IPConnectionCollector': 0,
                             'InterfaceCollector': 0,
                             'FirewallCollector': 0,
                             'MonitorCollector': 0,


### PR DESCRIPTION
I RouterOS v7, the response for the `/system/health` endpoint changed slightly.
The API returns a response like this:
`[{'name': 'temperature', 'value': '33', 'type': 'C'}, ...]`

This makes is impossible to just get the value of the desired metric by key, e.g. `voltage`.
Instead, it is necessary to get the records by name and then get its value afterwards.

My fix is working for both v6 and v7.

This PR also adds a new metric. The metric `ip_connections_total` measures the total number of IP connections at time X.