### PR TITLE
adds optional public IP address metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm IDE
+.idea/

--- a/mktxp/cli/config/config.py
+++ b/mktxp/cli/config/config.py
@@ -49,10 +49,10 @@ class MKTXPConfigKeys:
     FE_CAPSMAN_KEY = 'capsman'
     FE_CAPSMAN_CLIENTS_KEY = 'capsman_clients'
     FE_POE_KEY = 'poe'
+    FE_PUBLIC_IP_KEY = 'public_ip'
     FE_NETWATCH_KEY = 'netwatch'
 
     MKTXP_SOCKET_TIMEOUT = 'socket_timeout'    
-    MKTXP_SOCKET_TIMEOUT = 'socket_timeout'   
     MKTXP_INITIAL_DELAY = 'initial_delay_on_failure'
     MKTXP_MAX_DELAY = 'max_delay_on_failure'
     MKTXP_INC_DIV = 'delay_inc_div'
@@ -85,7 +85,8 @@ class MKTXPConfigKeys:
     # Feature keys enabled by default
     BOOLEAN_KEYS_YES = {FE_DHCP_KEY, FE_DHCP_LEASE_KEY, FE_DHCP_POOL_KEY, FE_IP_CONNECTIONS_KEY, FE_INTERFACE_KEY, FE_FIREWALL_KEY,
                       FE_MONITOR_KEY, FE_ROUTE_KEY, MKTXP_USE_COMMENTS_OVER_NAMES, 
-                      FE_WIRELESS_KEY, FE_WIRELESS_CLIENTS_KEY, FE_CAPSMAN_KEY, FE_CAPSMAN_CLIENTS_KEY, FE_POE_KEY, FE_NETWATCH_KEY}
+                      FE_WIRELESS_KEY, FE_WIRELESS_CLIENTS_KEY, FE_CAPSMAN_KEY, FE_CAPSMAN_CLIENTS_KEY, FE_POE_KEY,
+                      FE_NETWATCH_KEY, FE_PUBLIC_IP_KEY}
 
     SYSTEM_BOOLEAN_KEYS_YES = {MKTXP_BANDWIDTH_KEY}
     SYSTEM_BOOLEAN_KEYS_NO = {MKTXP_VERBOSE_MODE}
@@ -104,7 +105,8 @@ class ConfigEntry:
 
                                                  MKTXPConfigKeys.FE_DHCP_KEY, MKTXPConfigKeys.FE_DHCP_LEASE_KEY, MKTXPConfigKeys.FE_DHCP_POOL_KEY, MKTXPConfigKeys.FE_INTERFACE_KEY, MKTXPConfigKeys.FE_FIREWALL_KEY,
                                                  MKTXPConfigKeys.FE_MONITOR_KEY, MKTXPConfigKeys.FE_ROUTE_KEY, MKTXPConfigKeys.FE_WIRELESS_KEY, MKTXPConfigKeys.FE_WIRELESS_CLIENTS_KEY, MKTXPConfigKeys.FE_IP_CONNECTIONS_KEY,
-                                                 MKTXPConfigKeys.FE_CAPSMAN_KEY, MKTXPConfigKeys.FE_CAPSMAN_CLIENTS_KEY, MKTXPConfigKeys.FE_POE_KEY, MKTXPConfigKeys.FE_NETWATCH_KEY, MKTXPConfigKeys.MKTXP_USE_COMMENTS_OVER_NAMES
+                                                 MKTXPConfigKeys.FE_CAPSMAN_KEY, MKTXPConfigKeys.FE_CAPSMAN_CLIENTS_KEY, MKTXPConfigKeys.FE_POE_KEY, MKTXPConfigKeys.FE_NETWATCH_KEY, MKTXPConfigKeys.MKTXP_USE_COMMENTS_OVER_NAMES,
+                                                 MKTXPConfigKeys.FE_PUBLIC_IP_KEY,
                                                  ])
     MKTXPSystemEntry = namedtuple('MKTXPSystemEntry', [MKTXPConfigKeys.PORT_KEY, MKTXPConfigKeys.MKTXP_SOCKET_TIMEOUT,
                                                   MKTXPConfigKeys.MKTXP_INITIAL_DELAY, MKTXPConfigKeys.MKTXP_MAX_DELAY,

--- a/mktxp/cli/config/mktxp.conf
+++ b/mktxp/cli/config/mktxp.conf
@@ -32,6 +32,7 @@
     firewall = True                 # Firewall rules traffic metrics
     monitor = True                  # Interface monitor metrics
     poe = True                      # POE metrics
+    public_ip = True                # Public IP metrics
     route = True                    # Routes metrics
     wireless = True                 # WLAN general metrics
     wireless_clients = True         # WLAN clients metrics

--- a/mktxp/collector/public_ip_collector.py
+++ b/mktxp/collector/public_ip_collector.py
@@ -1,0 +1,31 @@
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+
+from mktxp.collector.base_collector import BaseCollector
+from mktxp.datasource.public_ip_ds import PublicIPAddressDatasource
+
+
+class PublicIPAddressCollector(BaseCollector):
+    '''Public IP address collector'''
+    @staticmethod
+    def collect(router_entry):
+        if not router_entry.config_entry.public_ip:
+            return
+
+        address_labels = ['public_address', ]
+        address_records = PublicIPAddressDatasource.metric_records(router_entry, metric_labels=address_labels)
+        if address_records:
+            address_metrics = BaseCollector.info_collector('public_ip_address', 'Public IP address', address_records, address_labels)
+            yield address_metrics
+

--- a/mktxp/datasource/public_ip_ds.py
+++ b/mktxp/datasource/public_ip_ds.py
@@ -1,0 +1,27 @@
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+from mktxp.datasource.base_ds import BaseDSProcessor
+
+class PublicIPAddressDatasource:
+    @staticmethod
+    def metric_records(router_entry, *, metric_labels = None):
+        if metric_labels is None:
+            metric_labels = []
+
+        try:
+            records = router_entry.api_connection.router_api().get_resource('/ip/cloud/').get()
+            return BaseDSProcessor.trimmed_records(router_entry, router_records=records, metric_labels = metric_labels)
+        except Exception as exc:
+            print(f'Error public IP address info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
+            return None

--- a/mktxp/flow/collector_registry.py
+++ b/mktxp/flow/collector_registry.py
@@ -18,6 +18,7 @@ from mktxp.collector.connection_collector import IPConnectionCollector
 from mktxp.collector.interface_collector import InterfaceCollector
 from mktxp.collector.health_collector import HealthCollector
 from mktxp.collector.identity_collector import IdentityCollector
+from mktxp.collector.public_ip_collector import PublicIPAddressCollector
 from mktxp.collector.monitor_collector import MonitorCollector
 from mktxp.collector.poe_collector import POECollector
 from mktxp.collector.netwatch_collector import NetwatchCollector
@@ -43,6 +44,7 @@ class CollectorRegistry:
         self.register('IdentityCollector', IdentityCollector.collect)
         self.register('SystemResourceCollector', SystemResourceCollector.collect)
         self.register('HealthCollector', HealthCollector.collect)
+        self.register('PublicIPAddressCollector', PublicIPAddressCollector.collect)
 
         self.register('DHCPCollector', DHCPCollector.collect)
         self.register('IPConnectionCollector', IPConnectionCollector.collect)

--- a/mktxp/flow/router_entry.py
+++ b/mktxp/flow/router_entry.py
@@ -30,6 +30,7 @@ class RouterEntry:
         self.time_spent =  { 'IdentityCollector': 0,
                             'SystemResourceCollector': 0,
                             'HealthCollector': 0,
+                            'PublicIPAddressCollector': 0,
                             'DHCPCollector': 0,
                             'PoolCollector': 0,
                             'IPConnectionCollector': 0,


### PR DESCRIPTION
This PR adds the public IP address as a info metric. The output looks like this:

```txt
# HELP mktxp_public_ip_address_info Public IP address
# TYPE mktxp_public_ip_address_info gauge
mktxp_public_ip_address_info{public_address="109.42.112.253",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
```

This metric can be activated/deactivated in the config file.