### PR TITLE
adds capsman interface datasource

### DIFF
--- a/mktxp/collector/capsman_collector.py
+++ b/mktxp/collector/capsman_collector.py
@@ -16,7 +16,7 @@ from mktxp.cli.config.config import MKTXPConfigKeys
 from mktxp.flow.processor.output import BaseOutputProcessor
 from mktxp.collector.base_collector import BaseCollector
 from mktxp.datasource.dhcp_ds import DHCPMetricsDataSource
-from mktxp.datasource.capsman_ds import CapsmanCapsMetricsDataSource, CapsmanRegistrationsMetricsDataSource
+from mktxp.datasource.capsman_ds import CapsmanCapsMetricsDataSource, CapsmanRegistrationsMetricsDataSource, CapsmanInterfacesDatasource
 
 
 class CapsmanCollector(BaseCollector):
@@ -68,5 +68,11 @@ class CapsmanCollector(BaseCollector):
                 registration_metrics = BaseCollector.info_collector('capsman_clients_devices', 'Registered client devices info', 
                                         registration_records, ['dhcp_name', 'dhcp_address', 'rx_signal', 'ssid', 'tx_rate', 'rx_rate', 'interface', 'mac_address', 'uptime'])
                 yield registration_metrics
-    
+
+
+        remote_cap_interface_labels = ['name', 'configuration', 'mac_address', 'current_state', 'current_channel', 'current_registered_clients']
+        remote_cap_interface_records = CapsmanInterfacesDatasource.metric_records(router_entry, metric_labels = remote_cap_interface_labels)
+        if remote_cap_interface_records:
+            remote_caps_metrics = BaseCollector.info_collector('capsman_interfaces', 'CAPsMAN interfaces', remote_cap_interface_records, remote_cap_interface_labels)
+            yield remote_caps_metrics
 

--- a/mktxp/datasource/capsman_ds.py
+++ b/mktxp/datasource/capsman_ds.py
@@ -14,7 +14,6 @@
 
 from mktxp.datasource.base_ds import BaseDSProcessor
 
-
 class CapsmanCapsMetricsDataSource:
     ''' Caps Metrics data provider
     '''             
@@ -42,4 +41,20 @@ class CapsmanRegistrationsMetricsDataSource:
             return BaseDSProcessor.trimmed_records(router_entry, router_records = registration_table_records, metric_labels = metric_labels, add_router_id = add_router_id)
         except Exception as exc:
             print(f'Error getting caps-man registration table info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
+            return None
+
+
+class CapsmanInterfacesDatasource:
+    ''' Data provider for CAPsMaN interfaces
+    '''
+
+    @staticmethod
+    def metric_records(router_entry, *, metric_labels = None):
+        if metric_labels is None:
+            metric_labels = []                
+        try:
+            caps_interfaces = router_entry.api_connection.router_api().get_resource('/caps-man/interface').get()
+            return BaseDSProcessor.trimmed_records(router_entry, router_records = caps_interfaces, metric_labels = metric_labels)
+        except Exception as exc:
+            print(f'Error getting caps-man interfaces info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
             return None


### PR DESCRIPTION
This PR adds additional metrics about CAPsMan interfaces.

This is useful when operating multiple CAPs. By adding more metrics about the configuration, channel, frequency and mac address for each cap interface it is easier to debug wireless connectivity issues.

The new metrics roughly look like this (depending on the configuration):

```txt
# HELP mktxp_capsman_interfaces_info CAPsMAN interfaces
# TYPE mktxp_capsman_interfaces_info gauge
mktxp_capsman_interfaces_info{configuration="Config-2G",current_channel="2452/20-Ce/gn(20dBm)",current_registered_clients="4",current_state="running-ap",mac_address="FF:FF:FF:FF:FF:FF",name="cap1",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
mktxp_capsman_interfaces_info{configuration="Family-2G",current_channel="",current_registered_clients="1",current_state="running-ap",mac_address="FF:FF:FF:FF:FF:FF",name="cap2",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
mktxp_capsman_interfaces_info{configuration="Config-5G-ac",current_channel="5560/20-eeCe/ac/DP(27dBm)",current_registered_clients="1",current_state="running-ap",mac_address="FF:FF:FF:FF:FF:FF",name="cap3",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
mktxp_capsman_interfaces_info{configuration="Config-2G",current_channel="2412/20-Ce/gn(20dBm)",current_registered_clients="1",current_state="running-ap",mac_address="FF:FF:FF:FF:FF:FF",name="cap4",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
mktxp_capsman_interfaces_info{configuration="Family-2G",current_channel="",current_registered_clients="0",current_state="running-ap",mac_address="FF:FF:FF:FF:FF:FF,name="cap5",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
mktxp_capsman_interfaces_info{configuration="Config-5G-ac",current_channel="5180/20-Ceee/ac/P(23dBm)",current_registered_clients="0",current_state="running-ap",mac_address="FF:FF:FF:FF:FF:FF",name="cap6",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
mktxp_capsman_interfaces_info{configuration="Config-5G-ac",current_channel="5500/20-Ceee/ac/DP(27dBm)+5610/80/DP(27dBm)",current_registered_clients="0",current_state="running-ap",mac_address="FF:FF:FF:FF:FF:FF",name="cap7",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
mktxp_capsman_interfaces_info{configuration="Config-2G",current_channel="2412/20-Ce/gn(20dBm)",current_registered_clients="2",current_state="running-ap",mac_address="FF:FF:FF:FF:FF:FF",name="cap8",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
mktxp_capsman_interfaces_info{configuration="Family-2G",current_channel="",current_registered_clients="2",current_state="running-ap",mac_address="FF:FF:FF:FF:FF:FF",name="cap9",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
mktxp_capsman_interfaces_info{configuration="Config-5G-ac",current_channel="5200/20-eCee/ac/P(23dBm)",current_registered_clients="1",current_state="running-ap",mac_address="FF:FF:FF:FF:FF:FF",name="cap10",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
mktxp_capsman_interfaces_info{configuration="Config-5G-ac",current_channel="5680/20-eeCe/ac/DP(27dBm)+5530/80/DP(27dBm)",current_registered_clients="1",current_state="running-ap",mac_address="FF:FF:FF:FF:FF:FF",name="cap11",routerboard_address="10.0.10.1",routerboard_name="RB3011"} 1.0
```