### PR TITLE
monkey match the upstream API wrapper

### DIFF
--- a/mktxp/flow/router_connection.py
+++ b/mktxp/flow/router_connection.py
@@ -14,9 +14,22 @@
 
 import ssl
 import socket
+import collections
 from datetime import datetime
-from routeros_api import RouterOsApiPool
 from mktxp.cli.config.config import config_handler
+
+# Fix UTF-8 decode error
+# See: https://github.com/akpw/mktxp/issues/47
+# The RouterOS-api implicitly assumes that the API response is UTF-8 encoded.
+# But Mikrotik uses latin-1.
+# Because the upstream dependency is currently abandoned, this is a quick hack to solve the issue
+
+MIKROTIK_ENCODING = 'latin-1'
+import routeros_api.api_structure
+routeros_api.api_structure.StringField.get_python_value = lambda _, bytes:  bytes.decode(MIKROTIK_ENCODING) 
+routeros_api.api_structure.default_structure = collections.defaultdict(routeros_api.api_structure.StringField)
+
+from routeros_api import RouterOsApiPool
 
 
 class RouterAPIConnectionError(Exception):


### PR DESCRIPTION
Relates to https://github.com/akpw/mktxp/issues/47

This is a simple patch for the upstream RouterOS-api lib. With this issue in place, string fields are correctly decoded if they contain special characters.

I tested this by adding multiple special characters to a DHCP lease:

> mktxp_dhcp_lease_info{active_address="10.0.10.208",address="10.0.10.208",comment="ROCK äöó²³",host_name="ROCK",mac_address="FF:FF:FF:FF:FF:FF",routerboard_address="10.0.10.1",routerboard_name="RB3011",server="PROD_DHCP"} 377.0

Note the **äöó²³**. 