### PR TITLE
Add note regarding usage in Docker Swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ docker run -v "$(pwd)/mktxp:/home/mktxp/mktxp/" -p 49090:49090 -it --rm ghcr.io/
 #### MKTXP stack install
 [MKTXP Stack Getting Started](https://github.com/akpw/mktxp-stack#install--getting-started) provides similar instructions around editing the mktxp.conf file and, if needed, adding a dedicated API user to your Mikrotik RouterOS devices as mentioned below.
 
-**NOTE:** In the case usage within a [Docker Swarm](https://docs.docker.com/engine/swarm/) is desired, please do make sure to have all settings explicitly set in both the `mktxp.conf` and `_mktxp.conf` files.  
+💡 In the case usage within a [Docker Swarm](https://docs.docker.com/engine/swarm/) is desired, please do make sure to have all settings explicitly set in both the `mktxp.conf` and `_mktxp.conf` files.  
 Not doing this may cause [issues](https://github.com/akpw/mktxp/issues/55#issuecomment-1346693843) regarding a `read-only` filesystem.
 
 ## Mikrotik Device Config

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ docker run -v "$(pwd)/mktxp:/home/mktxp/mktxp/" -p 49090:49090 -it --rm ghcr.io/
 #### MKTXP stack install
 [MKTXP Stack Getting Started](https://github.com/akpw/mktxp-stack#install--getting-started) provides similar instructions around editing the mktxp.conf file and, if needed, adding a dedicated API user to your Mikrotik RouterOS devices as mentioned below.
 
+**NOTE:** In the case usage within a [Docker Swarm](https://docs.docker.com/engine/swarm/) is desired, please do make sure to have all settings explicitly set in both the `mktxp.conf` and `_mktxp.conf` files.  
+Not doing this may cause [issues](https://github.com/akpw/mktxp/issues/55#issuecomment-1346693843) regarding a `read-only` filesystem.
 
 ## Mikrotik Device Config
 For the purpose of RouterOS device monitoring, it's best to create a dedicated user with minimal required permissions. \


### PR DESCRIPTION
As per #55, add a note in the `MKTXP stack install` section regarding usage in Docker Swarm.

- Closes #55 