### PR TITLE
Added metrics for kid-control devices

### DIFF
--- a/mktxp/cli/config/config.py
+++ b/mktxp/cli/config/config.py
@@ -44,6 +44,7 @@ class CollectorKeys:
     CAPSMAN_COLLECTOR = 'CapsmanCollector'
     QUEUE_TREE_COLLECTOR = 'QueueTreeCollector'
     QUEUE_SIMPLE_COLLECTOR = 'QueueSimpleCollector'
+    KID_CONTROL_DEVICE_COLLECTOR = 'KidControlCollector'
     USER_COLLECTOR = 'UserCollector'
     MKTXP_COLLECTOR = 'MKTXPCollector'
 
@@ -90,6 +91,8 @@ class MKTXPConfigKeys:
 
     FE_CHECK_FOR_UPDATES = 'check_for_updates'
 
+    FE_KID_CONTROL_DEVICE = 'kid_control_devices'
+
     MKTXP_SOCKET_TIMEOUT = 'socket_timeout'
     MKTXP_INITIAL_DELAY = 'initial_delay_on_failure'
     MKTXP_MAX_DELAY = 'max_delay_on_failure'
@@ -129,7 +132,7 @@ class MKTXPConfigKeys:
     DEFAULT_MKTXP_TOTAL_MAX_SCRAPE_DURATION = 30
 
 
-    BOOLEAN_KEYS_NO = {ENABLED_KEY, SSL_KEY, NO_SSL_CERTIFICATE, FE_CHECK_FOR_UPDATES,
+    BOOLEAN_KEYS_NO = {ENABLED_KEY, SSL_KEY, NO_SSL_CERTIFICATE, FE_CHECK_FOR_UPDATES, FE_KID_CONTROL_DEVICE,
                        SSL_CERTIFICATE_VERIFY, FE_IPV6_FIREWALL_KEY, FE_IPV6_NEIGHBOR_KEY, FE_CONNECTION_STATS_KEY}
 
     # Feature keys enabled by default
@@ -159,7 +162,7 @@ class ConfigEntry:
                                                        MKTXPConfigKeys.FE_FIREWALL_KEY, MKTXPConfigKeys.FE_MONITOR_KEY, MKTXPConfigKeys.FE_ROUTE_KEY, MKTXPConfigKeys.FE_WIRELESS_KEY, MKTXPConfigKeys.FE_WIRELESS_CLIENTS_KEY,
                                                        MKTXPConfigKeys.FE_IP_CONNECTIONS_KEY, MKTXPConfigKeys.FE_CONNECTION_STATS_KEY, MKTXPConfigKeys.FE_CAPSMAN_KEY, MKTXPConfigKeys.FE_CAPSMAN_CLIENTS_KEY, MKTXPConfigKeys.FE_POE_KEY, MKTXPConfigKeys.FE_NETWATCH_KEY,
                                                        MKTXPConfigKeys.MKTXP_USE_COMMENTS_OVER_NAMES, MKTXPConfigKeys.FE_PUBLIC_IP_KEY, MKTXPConfigKeys.FE_IPV6_FIREWALL_KEY, MKTXPConfigKeys.FE_IPV6_NEIGHBOR_KEY,
-                                                       MKTXPConfigKeys.FE_USER_KEY, MKTXPConfigKeys.FE_QUEUE_KEY, MKTXPConfigKeys.FE_REMOTE_DHCP_ENTRY, MKTXPConfigKeys.FE_CHECK_FOR_UPDATES
+                                                       MKTXPConfigKeys.FE_USER_KEY, MKTXPConfigKeys.FE_QUEUE_KEY, MKTXPConfigKeys.FE_REMOTE_DHCP_ENTRY, MKTXPConfigKeys.FE_CHECK_FOR_UPDATES, MKTXPConfigKeys.FE_KID_CONTROL_DEVICE,
                                                        ])
     MKTXPSystemEntry = namedtuple('MKTXPSystemEntry', [MKTXPConfigKeys.PORT_KEY, MKTXPConfigKeys.MKTXP_SOCKET_TIMEOUT,
                                                        MKTXPConfigKeys.MKTXP_INITIAL_DELAY, MKTXPConfigKeys.MKTXP_MAX_DELAY,

--- a/mktxp/collector/kid_control_device_collector.py
+++ b/mktxp/collector/kid_control_device_collector.py
@@ -61,6 +61,7 @@ class KidDeviceCollector(BaseCollector):
                 'disabled': lambda value: '1' if value == 'true' else '0',
             }[monitor_label](value)
         except KeyError:
+            # default to just returning the value
             return value
 
     @staticmethod

--- a/mktxp/collector/kid_control_device_collector.py
+++ b/mktxp/collector/kid_control_device_collector.py
@@ -41,19 +41,19 @@ class KidDeviceCollector(BaseCollector):
             info_metrics = BaseCollector.info_collector('kid_control_device', 'Kid-control device Info', records, info_labels)
             yield info_metrics
 
-            bytes_down_metrics = BaseCollector.gauge_collector('kid_control_device_bytes_down', 'Kid-control device bytes down', records, 'bytes_down', ['name'])
+            bytes_down_metrics = BaseCollector.gauge_collector('kid_control_device_bytes_down', 'Kid-control device bytes down', records, 'bytes_down', ['name', 'mac_address'])
             yield bytes_down_metrics
 
-            bytes_up_metrics = BaseCollector.gauge_collector('kid_control_device_bytes_up', 'Kid-control device bytes up', records, 'bytes_up', ['name'])
+            bytes_up_metrics = BaseCollector.gauge_collector('kid_control_device_bytes_up', 'Kid-control device bytes up', records, 'bytes_up', ['name', 'mac_address'])
             yield bytes_up_metrics
 
-            rate_down_metrics = BaseCollector.gauge_collector('kid_control_device_rate_down', 'Kid-control device rate down', records, 'rate_down', ['name'])
+            rate_down_metrics = BaseCollector.gauge_collector('kid_control_device_rate_down', 'Kid-control device rate down', records, 'rate_down', ['name', 'mac_address'])
             yield rate_down_metrics
 
-            rate_up_metrics = BaseCollector.gauge_collector('kid_control_device_rate_up', 'Kid-control device rate up', records, 'rate_up', ['name'])
+            rate_up_metrics = BaseCollector.gauge_collector('kid_control_device_rate_up', 'Kid-control device rate up', records, 'rate_up', ['name', 'mac_address'])
             yield rate_up_metrics
 
-            idle_time_metrics = BaseCollector.gauge_collector('kid_control_device_idle_time', 'Kid-control device idle time', records, 'idle_time', ['name'])
+            idle_time_metrics = BaseCollector.gauge_collector('kid_control_device_idle_time', 'Kid-control device idle time', records, 'idle_time', ['name', 'mac_address'])
             yield idle_time_metrics
 
     # Helpers

--- a/mktxp/collector/kid_control_device_collector.py
+++ b/mktxp/collector/kid_control_device_collector.py
@@ -18,17 +18,19 @@ from mktxp.datasource.kid_control_device_ds import KidDeviceMetricsDataSource
 
 
 class KidDeviceCollector(BaseCollector):
-    ''' Kid-control device Metrics collector
-    '''    
+    """ Kid-control device Metrics collector
+    """
+
     @staticmethod
     def collect(router_entry):
         if not router_entry.config_entry.kid_control_devices:
             return
 
-        labels = ['name', 'user', 'mac_address', 'ip_address', 'bytes_down', 'bytes_up', 'rate_up', 'rate_down', 'bytes_up', 'idle_time',
+        labels = ['name', 'user', 'mac_address', 'ip_address', 'bytes_down', 'bytes_up', 'rate_up', 'rate_down',
+                  'bytes_up', 'idle_time',
                   'blocked', 'limited', 'inactive', 'disabled']
         info_labels = ['name', 'user', 'mac_address', 'ip_address', 'disabled']
-        records = KidDeviceMetricsDataSource.metric_records(router_entry, metric_labels = labels)
+        records = KidDeviceMetricsDataSource.metric_records(router_entry, metric_labels=labels)
 
         if records:
             # translate records to appropriate values
@@ -38,23 +40,12 @@ class KidDeviceCollector(BaseCollector):
                     if value:
                         record[label] = KidDeviceCollector._translated_values(label, value)
 
-            info_metrics = BaseCollector.info_collector('kid_control_device', 'Kid-control device Info', records, info_labels)
-            yield info_metrics
-
-            bytes_down_metrics = BaseCollector.gauge_collector('kid_control_device_bytes_down', 'Kid-control device bytes down', records, 'bytes_down', ['name', 'mac_address'])
-            yield bytes_down_metrics
-
-            bytes_up_metrics = BaseCollector.gauge_collector('kid_control_device_bytes_up', 'Kid-control device bytes up', records, 'bytes_up', ['name', 'mac_address'])
-            yield bytes_up_metrics
-
-            rate_down_metrics = BaseCollector.gauge_collector('kid_control_device_rate_down', 'Kid-control device rate down', records, 'rate_down', ['name', 'mac_address'])
-            yield rate_down_metrics
-
-            rate_up_metrics = BaseCollector.gauge_collector('kid_control_device_rate_up', 'Kid-control device rate up', records, 'rate_up', ['name', 'mac_address'])
-            yield rate_up_metrics
-
-            idle_time_metrics = BaseCollector.gauge_collector('kid_control_device_idle_time', 'Kid-control device idle time', records, 'idle_time', ['name', 'mac_address'])
-            yield idle_time_metrics
+            yield BaseCollector.info_collector('kid_control_device', 'Kid-control device Info', records, info_labels)
+            yield BaseCollector.gauge_collector('kid_control_device_bytes_down', 'Kid-control device bytes down', records, 'bytes_down', ['name', 'mac_address'])
+            yield BaseCollector.gauge_collector('kid_control_device_bytes_up', 'Kid-control device bytes up', records, 'bytes_up', ['name', 'mac_address'])
+            yield BaseCollector.gauge_collector('kid_control_device_rate_down', 'Kid-control device rate down', records, 'rate_down', ['name', 'mac_address'])
+            yield BaseCollector.gauge_collector('kid_control_device_rate_up', 'Kid-control device rate up', records, 'rate_up', ['name', 'mac_address'])
+            yield BaseCollector.gauge_collector('kid_control_device_idle_time', 'Kid-control device idle time', records, 'idle_time', ['name', 'mac_address'])
 
     # Helpers
     @staticmethod
@@ -64,10 +55,10 @@ class KidDeviceCollector(BaseCollector):
                 'rate_up': lambda value: KidDeviceCollector._rates(value),
                 'rate_down': lambda value: KidDeviceCollector._rates(value),
                 'idle_time': lambda value: BaseOutputProcessor.parse_timedelta_seconds(value),
-                'blocked': lambda value: '1' if value=='true' else '0',
-                'limited': lambda value: '1' if value=='true' else '0',
-                'inactive': lambda value: '1' if value=='true' else '0',
-                'disabled': lambda value: '1' if value=='true' else '0',
+                'blocked': lambda value: '1' if value == 'true' else '0',
+                'limited': lambda value: '1' if value == 'true' else '0',
+                'inactive': lambda value: '1' if value == 'true' else '0',
+                'disabled': lambda value: '1' if value == 'true' else '0',
             }[monitor_label](value)
         except KeyError:
             return value
@@ -75,7 +66,7 @@ class KidDeviceCollector(BaseCollector):
     @staticmethod
     def _rates(rate_option):
         # according mikrotik docs, an interface rate should be one of these
-        rate_value =  {
+        rate_value = {
             '10Mbps': '10',
             '100Mbps': '100',
             '1Gbps': '1000',

--- a/mktxp/collector/kid_control_device_collector.py
+++ b/mktxp/collector/kid_control_device_collector.py
@@ -1,0 +1,91 @@
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+
+from mktxp.collector.base_collector import BaseCollector
+from mktxp.flow.processor.output import BaseOutputProcessor
+from mktxp.datasource.kid_control_device_ds import KidDeviceMetricsDataSource
+
+
+class KidDeviceCollector(BaseCollector):
+    ''' Kid-control device Metrics collector
+    '''    
+    @staticmethod
+    def collect(router_entry):
+        if not router_entry.config_entry.kid_control_devices:
+            return
+
+        labels = ['name', 'user', 'mac_address', 'ip_address', 'bytes_down', 'bytes_up', 'rate_up', 'rate_down', 'bytes_up', 'idle_time',
+                  'blocked', 'limited', 'inactive', 'disabled']
+        info_labels = ['name', 'user', 'mac_address', 'ip_address', 'disabled']
+        records = KidDeviceMetricsDataSource.metric_records(router_entry, metric_labels = labels)
+
+        if records:
+            # translate records to appropriate values
+            for record in records:
+                for label in record:
+                    value = record.get(label, None)
+                    if value:
+                        record[label] = KidDeviceCollector._translated_values(label, value)
+
+            info_metrics = BaseCollector.info_collector('kid_control_device', 'Kid-control device Info', records, info_labels)
+            yield info_metrics
+
+            bytes_down_metrics = BaseCollector.gauge_collector('kid_control_device_bytes_down', 'Kid-control device bytes down', records, 'bytes_down', ['name'])
+            yield bytes_down_metrics
+
+            bytes_up_metrics = BaseCollector.gauge_collector('kid_control_device_bytes_up', 'Kid-control device bytes up', records, 'bytes_up', ['name'])
+            yield bytes_up_metrics
+
+            rate_down_metrics = BaseCollector.gauge_collector('kid_control_device_rate_down', 'Kid-control device rate down', records, 'rate_down', ['name'])
+            yield rate_down_metrics
+
+            rate_up_metrics = BaseCollector.gauge_collector('kid_control_device_rate_up', 'Kid-control device rate up', records, 'rate_up', ['name'])
+            yield rate_up_metrics
+
+            idle_time_metrics = BaseCollector.gauge_collector('kid_control_device_idle_time', 'Kid-control device idle time', records, 'idle_time', ['name'])
+            yield idle_time_metrics
+
+    # Helpers
+    @staticmethod
+    def _translated_values(monitor_label, value):
+        try:
+            return {
+                'rate_up': lambda value: KidDeviceCollector._rates(value),
+                'rate_down': lambda value: KidDeviceCollector._rates(value),
+                'idle_time': lambda value: BaseOutputProcessor.parse_timedelta_seconds(value),
+                'blocked': lambda value: '1' if value=='true' else '0',
+                'limited': lambda value: '1' if value=='true' else '0',
+                'inactive': lambda value: '1' if value=='true' else '0',
+                'disabled': lambda value: '1' if value=='true' else '0',
+            }[monitor_label](value)
+        except KeyError:
+            return value
+
+    @staticmethod
+    def _rates(rate_option):
+        # according mikrotik docs, an interface rate should be one of these
+        rate_value =  {
+            '10Mbps': '10',
+            '100Mbps': '100',
+            '1Gbps': '1000',
+            '2.5Gbps': '2500',
+            '5Gbps': '5000',
+            '10Gbps': '10000',
+            '40Gbps': '40000'
+        }.get(rate_option, None)
+        if rate_value:
+            return rate_value
+
+        # ...or just calculate in case it's not
+        return BaseOutputProcessor.parse_interface_rate(rate_option)

--- a/mktxp/datasource/kid_control_device_ds.py
+++ b/mktxp/datasource/kid_control_device_ds.py
@@ -1,0 +1,31 @@
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+
+from mktxp.datasource.base_ds import BaseDSProcessor
+
+
+class KidDeviceMetricsDataSource:
+    ''' Kid-control device Metrics data provider
+    '''             
+    @staticmethod
+    def metric_records(router_entry, *, metric_labels = None):
+        if metric_labels is None:
+            metric_labels = []                
+        try:
+            device_records = router_entry.api_connection.router_api().get_resource('/ip/kid-control/device').get()
+            return BaseDSProcessor.trimmed_records(router_entry, router_records = device_records, metric_labels = metric_labels)
+        except Exception as exc:
+            print(f'Error getting Kid-control device info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
+            return None
+

--- a/mktxp/datasource/kid_control_device_ds.py
+++ b/mktxp/datasource/kid_control_device_ds.py
@@ -16,16 +16,17 @@ from mktxp.datasource.base_ds import BaseDSProcessor
 
 
 class KidDeviceMetricsDataSource:
-    ''' Kid-control device Metrics data provider
-    '''             
+    """ Kid-control device Metrics data provider
+    """
+
     @staticmethod
-    def metric_records(router_entry, *, metric_labels = None):
+    def metric_records(router_entry, *, metric_labels=None):
         if metric_labels is None:
-            metric_labels = []                
+            metric_labels = []
         try:
             device_records = router_entry.api_connection.router_api().get_resource('/ip/kid-control/device').get()
-            return BaseDSProcessor.trimmed_records(router_entry, router_records = device_records, metric_labels = metric_labels)
+            return BaseDSProcessor.trimmed_records(router_entry, router_records=device_records, metric_labels=metric_labels)
         except Exception as exc:
-            print(f'Error getting Kid-control device info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
+            print(
+                f'Error getting Kid-control device info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
             return None
-

--- a/mktxp/flow/collector_registry.py
+++ b/mktxp/flow/collector_registry.py
@@ -36,6 +36,7 @@ from mktxp.collector.mktxp_collector import MKTXPCollector
 from mktxp.collector.user_collector import UserCollector
 from mktxp.collector.queue_collector import QueueTreeCollector
 from mktxp.collector.queue_collector import QueueSimpleCollector
+from mktxp.collector.kid_control_device_collector import KidDeviceCollector
 
 class CollectorRegistry:
     ''' MKTXP Collectors Registry
@@ -71,6 +72,8 @@ class CollectorRegistry:
         self.register(CollectorKeys.USER_COLLECTOR, UserCollector.collect)
         self.register(CollectorKeys.QUEUE_TREE_COLLECTOR, QueueTreeCollector.collect)
         self.register(CollectorKeys.QUEUE_SIMPLE_COLLECTOR, QueueSimpleCollector.collect)
+
+        self.register(CollectorKeys.KID_CONTROL_DEVICE_COLLECTOR, KidDeviceCollector.collect)
 
         self.register(CollectorKeys.MKTXP_COLLECTOR, MKTXPCollector.collect)
 

--- a/mktxp/flow/router_entry.py
+++ b/mktxp/flow/router_entry.py
@@ -49,7 +49,8 @@ class RouterEntry:
                             CollectorKeys.CAPSMAN_COLLECTOR: 0,
                             CollectorKeys.QUEUE_TREE_COLLECTOR: 0,
                             CollectorKeys.QUEUE_SIMPLE_COLLECTOR: 0,                            
-                            CollectorKeys.USER_COLLECTOR: 0,                            
+                            CollectorKeys.KID_CONTROL_DEVICE_COLLECTOR: 0,
+                            CollectorKeys.USER_COLLECTOR: 0,
                             CollectorKeys.MKTXP_COLLECTOR: 0
                             }         
         self._dhcp_entry = None


### PR DESCRIPTION
This PR adds metrics for kid-control devices.
It creates an info metric like this:
```
mktxp_kid_control_device_info{disabled="0",ip_address="192.168.88.21",mac_address="DE:AD:BE:EF",name="my device,routerboard_address="192.168.88.1",routerboard_name="test",user="kid1"} 1.0
```

And various metrics:
```
mktxp_kid_control_device_bytes_down{name="my device",mac_address="DE:AD:BE:EF",routerboard_address="192.168.88.1",routerboard_name="test"} 5.007774e+06
mktxp_kid_control_device_bytes_up{name="my device",mac_address="DE:AD:BE:EF",routerboard_address="192.168.88.1",routerboard_name="test"} 3.173021e+06
mktxp_kid_control_device_rate_down{name="my device",mac_address="DE:AD:BE:EF",routerboard_address="192.168.88.1",routerboard_name="test"} 0.0
mktxp_kid_control_device_rate_up{name="my device",mac_address="DE:AD:BE:EF",routerboard_address="192.168.88.1",routerboard_name="test"} 0.0
mktxp_kid_control_device_idle_time{name="my device",mac_address="DE:AD:BE:EF",routerboard_address="192.168.88.1",routerboard_name="test"} 92.0
```