### PR TITLE
More netwatch metrics

### DIFF
--- a/mktxp/collector/netwatch_collector.py
+++ b/mktxp/collector/netwatch_collector.py
@@ -47,21 +47,24 @@ class NetwatchCollector(BaseCollector):
             yield BaseCollector.gauge_collector('netwatch_failed_tests', 'Netwatch Failed Tests', netwatch_records, 'failed_tests', ['name', 'type'])
 
             # ICMP specific
-            yield BaseCollector.gauge_collector('netwatch_icmp_loss_count', 'Netwatch ICMP Loss Count', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'loss_count', ['name', 'type'])
-            yield BaseCollector.gauge_collector('netwatch_icmp_loss_percent', 'Netwatch ICMP Loss Percent', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'loss_percent', ['name', 'type'])
-            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_avg_ms', 'Netwatch ICMP Round Trip Average', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'rtt_avg', ['name', 'type'])
-            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_min_ms', 'Netwatch ICMP Round Trip Min', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'rtt_min', ['name', 'type'])
-            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_max_ms', 'Netwatch ICMP Round Trip Max', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'rtt_max', ['name', 'type'])
-            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_jitter_ms', 'Netwatch ICMP Round Trip Jitter', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'rtt_jitter', ['name', 'type'])
-            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_stdev_ms', 'Netwatch ICMP Round Trip Stdev', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'rtt_stdev', ['name', 'type'])
+            icmp_records = [record for record in netwatch_records if record.get("type", None) == "icmp"]
+            yield BaseCollector.gauge_collector('netwatch_icmp_loss_count', 'Netwatch ICMP Loss Count', icmp_records, 'loss_count', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_loss_percent', 'Netwatch ICMP Loss Percent', icmp_records, 'loss_percent', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_avg_ms', 'Netwatch ICMP Round Trip Average', icmp_records, 'rtt_avg', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_min_ms', 'Netwatch ICMP Round Trip Min', icmp_records, 'rtt_min', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_max_ms', 'Netwatch ICMP Round Trip Max', icmp_records, 'rtt_max', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_jitter_ms', 'Netwatch ICMP Round Trip Jitter', icmp_records, 'rtt_jitter', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_stdev_ms', 'Netwatch ICMP Round Trip Stdev', icmp_records, 'rtt_stdev', ['name', 'type'])
 
             # TCP specific
-            yield BaseCollector.gauge_collector('netwatch_tcp_connect_time_ms', 'Netwatch TCP Connect Time', [record for record in netwatch_records if record.get("type", None) == "tcp-conn"], 'tcp_connect_time', ['name', 'type'])
+            tcp_records = [record for record in netwatch_records if record.get("type", None) == "tcp-conn"]
+            yield BaseCollector.gauge_collector('netwatch_tcp_connect_time_ms', 'Netwatch TCP Connect Time', tcp_records, 'tcp_connect_time', ['name', 'type'])
 
             # HTTP(s) specific
-            yield BaseCollector.gauge_collector('netwatch_http_status_code', 'Netwatch HTTP status code', [record for record in netwatch_records if record.get("type", None) in ["http-get", "https-get"]], 'http_status_code', ['name', 'type'])
-            yield BaseCollector.gauge_collector('netwatch_http_resp_time', 'Netwatch HTTP status code', [record for record in netwatch_records if record.get("type", None) in ["http-get", "https-get"]], 'http_resp_time', ['name', 'type'])
-            yield BaseCollector.gauge_collector('netwatch_tcp_connect_time_ms', 'Netwatch TCP Connect Time', [record for record in netwatch_records if record.get("type", None) in ["http-get", "https-get"]], 'tcp_connect_time', ['name', 'type'])
+            http_records = [record for record in netwatch_records if record.get("type", None) in ["http-get", "https-get"]]
+            yield BaseCollector.gauge_collector('netwatch_http_status_code', 'Netwatch HTTP status code', http_records, 'http_status_code', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_http_resp_time', 'Netwatch HTTP status code', http_records, 'http_resp_time', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_tcp_connect_time_ms', 'Netwatch TCP Connect Time', http_records, 'tcp_connect_time', ['name', 'type'])
 
     # Helpers
     @staticmethod

--- a/mktxp/collector/netwatch_collector.py
+++ b/mktxp/collector/netwatch_collector.py
@@ -12,8 +12,9 @@
 ## GNU General Public License for more details.
 
 
+import re
+from datetime import timedelta
 from mktxp.collector.base_collector import BaseCollector
-from mktxp.flow.processor.output import BaseOutputProcessor
 from mktxp.datasource.netwatch_ds import NetwatchMetricsDataSource
 
 
@@ -25,11 +26,61 @@ class NetwatchCollector(BaseCollector):
         if not router_entry.config_entry.netwatch:
             return
 
-        netwatch_labels = ['host', 'timeout', 'interval', 'since', 'status', 'comment', 'name']
-        netwatch_records = NetwatchMetricsDataSource.metric_records(router_entry, metric_labels = netwatch_labels)  
+        netwatch_labels = ['host', 'timeout', 'interval', 'since', 'status', 'comment', 'name', "done_tests", "type", "failed_tests",
+                           "loss_count", "loss_percent", "rtt_avg", "rtt_min", "rtt_max", "rtt_jitter", "rtt_stdev",
+                           "tcp_connect_time", "http_status_code", "http_resp_time",
+                           ]
+        netwatch_info_labels = ['host', 'timeout', 'interval', 'since', 'status', 'comment', 'name']
+        netwatch_records = NetwatchMetricsDataSource.metric_records(router_entry, metric_labels = netwatch_labels)
 
         if netwatch_records:
-            yield BaseCollector.info_collector('netwatch', 'Netwatch Info Metrics', netwatch_records, netwatch_labels)
+            for record in netwatch_records:
+                for label in record:
+                    value = record.get(label, None)
+                    if value:
+                        record[label] = NetwatchCollector._translated_values(label, value)
 
-            yield BaseCollector.gauge_collector('netwatch_status', 'Netwatch Status Metrics', netwatch_records, 'status', ['name'])
-            
+            yield BaseCollector.info_collector('netwatch', 'Netwatch Info Metrics', netwatch_records, netwatch_info_labels)
+
+            yield BaseCollector.gauge_collector('netwatch_status', 'Netwatch Status Metrics', netwatch_records, 'status', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_done_tests', 'Netwatch Done Tests', netwatch_records, 'done_tests', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_failed_tests', 'Netwatch Failed Tests', netwatch_records, 'failed_tests', ['name', 'type'])
+
+            # ICMP specific
+            yield BaseCollector.gauge_collector('netwatch_icmp_loss_count', 'Netwatch ICMP Loss Count', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'loss_count', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_loss_percent', 'Netwatch ICMP Loss Percent', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'loss_percent', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_avg_ms', 'Netwatch ICMP Round Trip Average', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'rtt_avg', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_min_ms', 'Netwatch ICMP Round Trip Min', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'rtt_min', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_max_ms', 'Netwatch ICMP Round Trip Max', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'rtt_max', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_jitter_ms', 'Netwatch ICMP Round Trip Jitter', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'rtt_jitter', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_icmp_rtt_stdev_ms', 'Netwatch ICMP Round Trip Stdev', [record for record in netwatch_records if record.get("type", None) == "icmp"], 'rtt_stdev', ['name', 'type'])
+
+            # TCP specific
+            yield BaseCollector.gauge_collector('netwatch_tcp_connect_time_ms', 'Netwatch TCP Connect Time', [record for record in netwatch_records if record.get("type", None) == "tcp-conn"], 'tcp_connect_time', ['name', 'type'])
+
+            # HTTP(s) specific
+            yield BaseCollector.gauge_collector('netwatch_http_status_code', 'Netwatch HTTP status code', [record for record in netwatch_records if record.get("type", None) in ["http-get", "https-get"]], 'http_status_code', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_http_resp_time', 'Netwatch HTTP status code', [record for record in netwatch_records if record.get("type", None) in ["http-get", "https-get"]], 'http_resp_time', ['name', 'type'])
+            yield BaseCollector.gauge_collector('netwatch_tcp_connect_time_ms', 'Netwatch TCP Connect Time', [record for record in netwatch_records if record.get("type", None) in ["http-get", "https-get"]], 'tcp_connect_time', ['name', 'type'])
+
+    # Helpers
+    @staticmethod
+    def _translated_values(label, value):
+        try:
+            return {
+                'rtt_avg': lambda value: NetwatchCollector.parse_timedelta(value).microseconds/1000,
+                'rtt_min': lambda value: NetwatchCollector.parse_timedelta(value).microseconds/1000,
+                'rtt_max': lambda value: NetwatchCollector.parse_timedelta(value).microseconds/1000,
+                'rtt_jitter': lambda value: NetwatchCollector.parse_timedelta(value).microseconds/1000,
+                'rtt_stdev': lambda value: NetwatchCollector.parse_timedelta(value).microseconds/1000,
+                'tcp_connect_time': lambda value: NetwatchCollector.parse_timedelta(value).microseconds/1000,
+                'http_resp_time': lambda value: NetwatchCollector.parse_timedelta(value).microseconds/1000,
+            }[label](value)
+        except KeyError:
+            return value
+
+    @staticmethod
+    def parse_timedelta(time):
+        duration_interval_rgx = re.compile(r'((?P<seconds>\d+)s)?((?P<milliseconds>\d+)ms)?((?P<microseconds>\d+)us)?')
+        time_dict = duration_interval_rgx.match(time).groupdict()
+        return timedelta(**{key: int(value) for key, value in time_dict.items() if value})

--- a/mktxp/collector/netwatch_collector.py
+++ b/mktxp/collector/netwatch_collector.py
@@ -80,6 +80,7 @@ class NetwatchCollector(BaseCollector):
                 'http_resp_time': lambda value: NetwatchCollector.parse_timedelta(value).microseconds/1000,
             }[label](value)
         except KeyError:
+            # default to just returning the value
             return value
 
     @staticmethod


### PR DESCRIPTION
Added metrics for the different types: icmp, tcp, http, https.
Added the type label to the metrics, as it's possible to have more monitors with the same name (ip), but different types.

```
mktxp_netwatch_info{comment="",host="1.2.3.4",interval="1m",name="1.2.3.4",routerboard_address="192.168.88.1",routerboard_name="test",since="2023-11-02 22:31:49",status="1",timeout=""} 1.0
mktxp_netwatch_info{comment="",host="192.168.88.1",interval="",name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",since="2023-11-02 23:21:48",status="0",timeout=""} 1.0
mktxp_netwatch_info{comment="",host="192.168.88.1",interval="",name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",since="2023-11-02 23:21:58",status="0",timeout=""} 1.0
mktxp_netwatch_info{comment="",host="192.168.88.1",interval="",name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",since="2023-11-02 23:22:13",status="1",timeout=""} 1.0
mktxp_netwatch_status{name="1.2.3.4",routerboard_address="192.168.88.1",routerboard_name="test",type="icmp"} 1.0
mktxp_netwatch_status{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="http-get"} 0.0
mktxp_netwatch_status{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="https-get"} 0.0
mktxp_netwatch_status{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="tcp-conn"} 1.0
mktxp_netwatch_done_tests{name="1.2.3.4",routerboard_address="192.168.88.1",routerboard_name="test",type="icmp"} 58.0
mktxp_netwatch_done_tests{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="http-get"} 45.0
mktxp_netwatch_done_tests{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="https-get"} 44.0
mktxp_netwatch_done_tests{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="tcp-conn"} 43.0
mktxp_netwatch_failed_tests{name="1.2.3.4",routerboard_address="192.168.88.1",routerboard_name="test",type="icmp"} 0.0
mktxp_netwatch_failed_tests{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="http-get"} 45.0
mktxp_netwatch_failed_tests{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="https-get"} 44.0
mktxp_netwatch_failed_tests{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="tcp-conn"} 0.0
mktxp_netwatch_icmp_loss_count{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="icmp"} 0.0
mktxp_netwatch_icmp_loss_percent{name="1.2.3.4",routerboard_address="192.168.88.1",routerboard_name="test",type="icmp"} 0.0
mktxp_netwatch_icmp_rtt_avg_ms{name="1.2.3.4",routerboard_address="192.168.88.1",routerboard_name="test",type="icmp"} 1.094
mktxp_netwatch_icmp_rtt_min_ms{name="1.2.3.4",routerboard_address="192.168.88.1",routerboard_name="test",type="icmp"} 1.004
mktxp_netwatch_icmp_rtt_max_ms{name="1.2.3.4",routerboard_address="192.168.88.1",routerboard_name="test",type="icmp"} 1.141
mktxp_netwatch_icmp_rtt_jitter_ms{name="1.2.3.4",routerboard_address="192.168.88.1",routerboard_name="test",type="icmp"} 0.137
mktxp_netwatch_icmp_rtt_stdev_ms{name="1.2.3.4",routerboard_address="192.168.88.1",routerboard_name="test",type="icmp"} 0.051
mktxp_netwatch_tcp_connect_time_ms{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="tcp-conn"} 208.214
mktxp_netwatch_http_status_code{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="http-get"} 301.0
mktxp_netwatch_http_status_code{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="https-get"} 404.0
mktxp_netwatch_http_resp_time{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="http-get"} 255.43
mktxp_netwatch_http_resp_time{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="https-get"} 275.809
mktxp_netwatch_tcp_connect_time_ms{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="http-get"} 253.508
mktxp_netwatch_tcp_connect_time_ms{name="192.168.88.1",routerboard_address="192.168.88.1",routerboard_name="test",type="https-get"} 274.002

```