### PR TITLE
Add support for RouterOS version 7.13

### DIFF
--- a/mktxp/cli/output/wifi_out.py
+++ b/mktxp/cli/output/wifi_out.py
@@ -42,8 +42,8 @@ class WirelessOutput:
 
         output_records = 0
         registration_records = len(registration_records)                
-        output_entry = BaseOutputProcessor.OutputWiFiWave2Entry \
-                        if WirelessMetricsDataSource.wifiwave2_installed(router_entry) else BaseOutputProcessor.OutputWiFiEntry
+        output_entry = BaseOutputProcessor.OutputWiFiEntry \
+                        if WirelessMetricsDataSource.is_legacy(router_entry) else BaseOutputProcessor.OutputWirelessEntry
         output_table = BaseOutputProcessor.output_table(output_entry)
         
         for key in dhcp_rt_by_interface.keys():

--- a/mktxp/datasource/capsman_ds.py
+++ b/mktxp/datasource/capsman_ds.py
@@ -19,17 +19,19 @@ from mktxp.datasource.wireless_ds import WirelessMetricsDataSource
 class CapsmanInfo:
     @staticmethod
     def capsman_path(router_entry):
-        if WirelessMetricsDataSource.wifiwave2_installed(router_entry):
-            return '/interface/wifiwave2/capsman'
-        else:
+        if WirelessMetricsDataSource.is_legacy(router_entry):
             return '/caps-man'
+        else:
+            wireless_package = WirelessMetricsDataSource.wireless_package(router_entry)
+            return f'/interface/{wireless_package}/capsman'
 
     @staticmethod
     def registration_table_path(router_entry):
-        if WirelessMetricsDataSource.wifiwave2_installed(router_entry):
-            return '/interface/wifiwave2/registration-table'
-        else:
+        if WirelessMetricsDataSource.is_legacy(router_entry):
             return '/caps-man/registration-table'
+        else:
+            wireless_package = WirelessMetricsDataSource.wireless_package(router_entry)
+            return f'/interface/{wireless_package}/registration-table'
 
 class CapsmanCapsMetricsDataSource:
     ''' Caps Metrics data provider
@@ -76,7 +78,7 @@ class CapsmanInterfacesDatasource:
 
     @staticmethod
     def metric_records(router_entry, *, metric_labels = None):
-        if WirelessMetricsDataSource.wireless_package(router_entry) == WirelessMetricsDataSource.WIFIWAVE2:
+        if not WirelessMetricsDataSource.is_legacy(router_entry):
             return None            
         if metric_labels is None:
             metric_labels = []                

--- a/mktxp/datasource/wireless_ds.py
+++ b/mktxp/datasource/wireless_ds.py
@@ -21,6 +21,7 @@ class WirelessMetricsDataSource:
     '''             
     WIFIWAVE2 = 'wifiwave2'
     WIRELESS = 'wireless'
+    WIFI = 'wifi'
 
     @staticmethod
     def metric_records(router_entry, *, metric_labels = None, add_router_id = True):
@@ -45,10 +46,14 @@ class WirelessMetricsDataSource:
     @staticmethod
     def wireless_package(router_entry):
         if not router_entry.wifi_package:
-            ww2_installed = PackageMetricsDataSource.is_package_installed(router_entry, package_name = WirelessMetricsDataSource.WIFIWAVE2)
-            router_entry.wifi_package = WirelessMetricsDataSource.WIFIWAVE2 if ww2_installed else WirelessMetricsDataSource.WIRELESS
+            if PackageMetricsDataSource.is_package_installed(router_entry, package_name = WirelessMetricsDataSource.WIRELESS):
+              router_entry.wifi_package = WirelessMetricsDataSource.WIRELESS
+            elif PackageMetricsDataSource.is_package_installed(router_entry, package_name = WirelessMetricsDataSource.WIFIWAVE2):
+              router_entry.wifi_package = WirelessMetricsDataSource.WIFIWAVE2
+            else:
+              router_entry.wifi_package = WirelessMetricsDataSource.WIFI
         return router_entry.wifi_package
 
     @staticmethod
-    def wifiwave2_installed(router_entry):
-        return WirelessMetricsDataSource.wireless_package(router_entry) == WirelessMetricsDataSource.WIFIWAVE2
+    def is_legacy(router_entry):
+        return WirelessMetricsDataSource.wireless_package(router_entry) == WirelessMetricsDataSource.WIRELESS

--- a/mktxp/flow/processor/output.py
+++ b/mktxp/flow/processor/output.py
@@ -27,11 +27,11 @@ class BaseOutputProcessor:
     OutputCapsmanEntry = namedtuple('OutputCapsmanEntry', ['dhcp_name', 'dhcp_address', 'mac_address', 'rx_signal', 'interface', 'ssid', 'tx_rate', 'rx_rate', 'uptime'])
     OutputCapsmanEntry.__new__.__defaults__ = ('',) * len(OutputCapsmanEntry._fields)
 
-    OutputWiFiEntry = namedtuple('OutputWiFiEntry', ['dhcp_name', 'dhcp_address', 'mac_address', 'signal_strength', 'signal_to_noise', 'interface', 'tx_rate', 'rx_rate', 'uptime'])
-    OutputWiFiEntry.__new__.__defaults__ = ('',) * len(OutputWiFiEntry._fields)
+    OutputWirelessEntry = namedtuple('OutputWirelessEntry', ['dhcp_name', 'dhcp_address', 'mac_address', 'signal_strength', 'signal_to_noise', 'interface', 'tx_rate', 'rx_rate', 'uptime'])
+    OutputWirelessEntry.__new__.__defaults__ = ('',) * len(OutputWirelessEntry._fields)
 
-    OutputWiFiWave2Entry = namedtuple('OutputWiFiWave2Entry', ['dhcp_name', 'dhcp_address', 'mac_address', 'signal_strength', 'interface', 'tx_rate', 'rx_rate', 'uptime'])
-    OutputWiFiWave2Entry.__new__.__defaults__ = ('',) * len(OutputWiFiWave2Entry._fields)
+    OutputWiFiEntry = namedtuple('OutputWiFiEntry', ['dhcp_name', 'dhcp_address', 'mac_address', 'signal_strength', 'interface', 'tx_rate', 'rx_rate', 'uptime'])
+    OutputWiFiEntry.__new__.__defaults__ = ('',) * len(OutputWiFiEntry._fields)
 
     OutputDHCPEntry = namedtuple('OutputDHCPEntry', ['host_name', 'server', 'mac_address', 'address', 'active_address', 'expires_after'])
     OutputDHCPEntry.__new__.__defaults__ = ('',) * len(OutputDHCPEntry._fields)
@@ -50,13 +50,13 @@ class BaseOutputProcessor:
             registration_record['rx_bytes'] = registration_record['bytes'].split(',')[1]
             del registration_record['bytes']
 
-        ww2_installed = WirelessMetricsDataSource.wifiwave2_installed(router_entry)
+        is_legacy = WirelessMetricsDataSource.is_legacy(router_entry)
         if registration_record.get('tx_rate'):
             registration_record['tx_rate'] = BaseOutputProcessor.parse_bitrates(registration_record['tx_rate']) \
-                                                if ww2_installed else BaseOutputProcessor.parse_rates(registration_record['tx_rate'])
+                                                if not is_legacy else BaseOutputProcessor.parse_rates(registration_record['tx_rate'])
         if registration_record.get('rx_rate'):
             registration_record['rx_rate'] = BaseOutputProcessor.parse_bitrates(registration_record['rx_rate']) \
-                                                if ww2_installed else BaseOutputProcessor.parse_rates(registration_record['rx_rate'])
+                                                if not is_legacy else BaseOutputProcessor.parse_rates(registration_record['rx_rate'])
         if registration_record.get('uptime'):
             registration_record['uptime'] = naturaldelta(BaseOutputProcessor.parse_timedelta_seconds(registration_record['uptime']), months=True, minimum_unit='seconds')
 


### PR DESCRIPTION
As of RouterOS version 7.13, `/interface/wifiwave2` has been renamed to `/interface/wifi`.

> !) wifi - split existing "wifiwave2" package into separate packages
> "wifi-qcom", "wifi-qcom-ac", and include required utilities for WiFi
> management into bundle;

Please see links below for more information:

[1] https://mikrotik.com/download/changelogs/testing-release-tree
[2] https://help.mikrotik.com/docs/display/ROS/WiFi