### PR TITLE
Add Parsing of the routeros version for capsman metrics

### DIFF
--- a/mktxp/datasource/system_resource_ds.py
+++ b/mktxp/datasource/system_resource_ds.py
@@ -13,7 +13,7 @@
 
 
 from mktxp.datasource.base_ds import BaseDSProcessor
-from mktxp.utils.utils import is_wifi_version
+from mktxp.utils.utils import builtin_wifi_capsman_version
 
 
 class SystemResourceMetricsDataSource:
@@ -31,18 +31,20 @@ class SystemResourceMetricsDataSource:
             return None
 
     @staticmethod
-    def is_os_with_wifi_builtin(router_entry):
+    def os_version(router_entry):
         try:
-            system_resource_records = router_entry.api_connection.router_api().get_resource('/system/resource').get()
-            version = None
-            for record in system_resource_records:
-                if record['version']:
-                    version = record['version']
-                    break
-            if not version:
-                return False
-
-            return is_wifi_version(version)
+            system_version_records = router_entry.api_connection.router_api().get_resource('/system/resource').call('print', {'proplist':'version'})
+            for record in system_version_records:
+                ver = record.get('version', None)
+                if ver:
+                    return ver
+                    
+            return None
         except Exception as exc:
             print(f'Error getting system resource info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
         return False
+    
+    @staticmethod
+    def has_builtin_wifi_capsman(router_entry):
+        ver = SystemResourceMetricsDataSource.os_version(router_entry)
+        return builtin_wifi_capsman_version(ver)

--- a/mktxp/datasource/system_resource_ds.py
+++ b/mktxp/datasource/system_resource_ds.py
@@ -13,6 +13,7 @@
 
 
 from mktxp.datasource.base_ds import BaseDSProcessor
+from mktxp.utils.utils import is_wifi_version
 
 
 class SystemResourceMetricsDataSource:
@@ -28,3 +29,20 @@ class SystemResourceMetricsDataSource:
         except Exception as exc:
             print(f'Error getting system resource info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
             return None
+
+    @staticmethod
+    def is_os_with_wifi_builtin(router_entry):
+        try:
+            system_resource_records = router_entry.api_connection.router_api().get_resource('/system/resource').get()
+            version = ''
+            for record in system_resource_records:
+                if record['version']:
+                    version = record['version']
+                    break
+            if not version:
+                return False
+
+            return is_wifi_version(version)
+        except Exception as exc:
+            print(f'Error getting system resource info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
+        return False

--- a/mktxp/datasource/system_resource_ds.py
+++ b/mktxp/datasource/system_resource_ds.py
@@ -34,7 +34,7 @@ class SystemResourceMetricsDataSource:
     def is_os_with_wifi_builtin(router_entry):
         try:
             system_resource_records = router_entry.api_connection.router_api().get_resource('/system/resource').get()
-            version = ''
+            version = None
             for record in system_resource_records:
                 if record['version']:
                     version = record['version']

--- a/mktxp/flow/router_entry.py
+++ b/mktxp/flow/router_entry.py
@@ -84,7 +84,7 @@ class RouterEntry:
               self._wireless_type = RouterEntryWirelessType.WIFIWAVE2
             elif PackageMetricsDataSource.is_package_installed(router_entry, package_name = RouterEntryWirelessPackage.WIRELESS_PACKAGE):
               self._wireless_type = RouterEntryWirelessType.DUAL
-            elif SystemResourceMetricsDataSource.is_os_with_wifi_builtin(router_entry):
+            elif SystemResourceMetricsDataSource.has_builtin_wifi_capsman(router_entry):
               self._wireless_type = RouterEntryWirelessType.WIFI
             else:
               self._wireless_type = RouterEntryWirelessType.WIRELESS

--- a/mktxp/flow/router_entry.py
+++ b/mktxp/flow/router_entry.py
@@ -76,9 +76,7 @@ class RouterEntry:
     def wireless_type(self):
         router_entry = self
         if self._wireless_type == RouterEntryWirelessType.NONE:
-            if SystemResourceMetricsDataSource.is_os_with_wifi_builtin(router_entry):
-              self._wireless_type = RouterEntryWirelessType.WIFI
-            elif PackageMetricsDataSource.is_package_installed(router_entry, package_name = RouterEntryWirelessPackage.WIFI_PACKAGE):
+            if PackageMetricsDataSource.is_package_installed(router_entry, package_name = RouterEntryWirelessPackage.WIFI_PACKAGE):
               self._wireless_type = RouterEntryWirelessType.WIFI
             elif PackageMetricsDataSource.is_package_installed(router_entry, package_name = RouterEntryWirelessPackage.WIFI_AC_PACKAGE):
               self._wireless_type = RouterEntryWirelessType.WIFI
@@ -86,6 +84,8 @@ class RouterEntry:
               self._wireless_type = RouterEntryWirelessType.WIFIWAVE2
             elif PackageMetricsDataSource.is_package_installed(router_entry, package_name = RouterEntryWirelessPackage.WIRELESS_PACKAGE):
               self._wireless_type = RouterEntryWirelessType.DUAL
+            elif SystemResourceMetricsDataSource.is_os_with_wifi_builtin(router_entry):
+              self._wireless_type = RouterEntryWirelessType.WIFI
             else:
               self._wireless_type = RouterEntryWirelessType.WIRELESS
         return self._wireless_type

--- a/mktxp/flow/router_entry.py
+++ b/mktxp/flow/router_entry.py
@@ -17,6 +17,7 @@ from collections import namedtuple
 from mktxp.cli.config.config import config_handler, MKTXPConfigKeys, CollectorKeys
 from mktxp.flow.router_connection import RouterAPIConnection
 from mktxp.datasource.package_ds import PackageMetricsDataSource
+from mktxp.datasource.system_resource_ds import SystemResourceMetricsDataSource
 
 
 class RouterEntryWirelessType(IntEnum):
@@ -75,7 +76,9 @@ class RouterEntry:
     def wireless_type(self):
         router_entry = self
         if self._wireless_type == RouterEntryWirelessType.NONE:
-            if PackageMetricsDataSource.is_package_installed(router_entry, package_name = RouterEntryWirelessPackage.WIFI_PACKAGE):
+            if SystemResourceMetricsDataSource.is_os_with_wifi_builtin(router_entry):
+              self._wireless_type = RouterEntryWirelessType.WIFI
+            elif PackageMetricsDataSource.is_package_installed(router_entry, package_name = RouterEntryWirelessPackage.WIFI_PACKAGE):
               self._wireless_type = RouterEntryWirelessType.WIFI
             elif PackageMetricsDataSource.is_package_installed(router_entry, package_name = RouterEntryWirelessPackage.WIFI_AC_PACKAGE):
               self._wireless_type = RouterEntryWirelessType.WIFI

--- a/mktxp/utils/utils.py
+++ b/mktxp/utils/utils.py
@@ -324,6 +324,19 @@ def parse_ros_version(string):
     version, channel = re.findall(r'([\d\.]+).*?([\w]+)', string)[0]
     return packaging.version.parse(version), channel
 
+def is_wifi_version(string):
+    """Try to check if the version is Wifi version of RouterOS (> 7.13).
+    If anything goes wrong, return None.
+    Returns a boolean"""
+    try:
+        cur_version, _ = parse_ros_version(string)
+        if cur_version >= packaging.version.parse('7.13'):
+            return True
+    except Exception as err:
+        print(f'could not get current RouterOS version, because: {str(err)}')
+
+    return False
+
 def check_for_updates(cur_version):
     """Try to check if there is a newer version available.
     If anything goes wrong, it returns the same version.

--- a/mktxp/utils/utils.py
+++ b/mktxp/utils/utils.py
@@ -324,8 +324,8 @@ def parse_ros_version(string):
     version, channel = re.findall(r'([\d\.]+).*?([\w]+)', string)[0]
     return packaging.version.parse(version), channel
 
-def is_wifi_version(string):
-    """Try to check if the version is Wifi version of RouterOS (> 7.13).
+def builtin_wifi_capsman_version(string):
+    """Try to check if the version is Wifi version of RouterOS (>= 7.13).
     If anything goes wrong, return None.
     Returns a boolean"""
     try:
@@ -334,6 +334,7 @@ def is_wifi_version(string):
             return True
     except Exception as err:
         print(f'could not get current RouterOS version, because: {str(err)}')
+        return None
 
     return False
 


### PR DESCRIPTION
As stated in the issue: https://github.com/akpw/mktxp/issues/106
New versions of RouterOS (>7.13) have the wifi capsman ability builtin.

Added functionality to check if the routeros version is post 7.13, and use wifi wireless version if so.