### PR TITLE
Retry connection without plain text authentication

### DIFF
--- a/mktxp/flow/router_connection.py
+++ b/mktxp/flow/router_connection.py
@@ -78,7 +78,12 @@ class RouterAPIConnection:
             return
         try:
             print(f'Connecting to router {self.router_name}@{self.config_entry.hostname}')
-            self.api = self.connection.get_api()
+            try:
+                self.api = self.connection.get_api()
+            except:                
+                self.connection.plaintext_login = False
+                self.api = self.connection.get_api()
+
             self._set_connect_state(success = True, connect_time = connect_time)
         except (socket.error, socket.timeout, Exception) as exc:
             self._set_connect_state(success = False, connect_time = connect_time, exc = exc)


### PR DESCRIPTION
Routers running RouterOS versions below 6.43 do not support plain text authentication.
The connection process was improved to attempt both authentication methods.