### PR TITLE
feat: adds additional metrics for DHCP

### DIFF
--- a/mktxp/collector/dhcp_collector.py
+++ b/mktxp/collector/dhcp_collector.py
@@ -19,14 +19,14 @@ from mktxp.datasource.dhcp_ds import DHCPMetricsDataSource
 
 class DHCPCollector(BaseCollector):
     ''' DHCP Metrics collector
-    '''    
+    '''
     @staticmethod
     def collect(router_entry):
         if not router_entry.config_entry.dhcp:
             return
 
-        dhcp_lease_labels = ['active_address', 'address', 'mac_address', 'host_name', 'comment', 'server', 'expires_after']
-        dhcp_lease_records = DHCPMetricsDataSource.metric_records(router_entry, metric_labels = dhcp_lease_labels)   
+        dhcp_lease_labels = ['active_address', 'address', 'mac_address', 'host_name', 'comment', 'server', 'expires_after', 'last_seen', 'client_id', 'active_mac_address']
+        dhcp_lease_records = DHCPMetricsDataSource.metric_records(router_entry, metric_labels = dhcp_lease_labels)
         if dhcp_lease_records:
             # calculate number of leases per DHCP server
             dhcp_lease_servers = {}
@@ -38,17 +38,17 @@ class DHCPCollector(BaseCollector):
             dhcp_lease_servers_records = [{ MKTXPConfigKeys.ROUTERBOARD_NAME: router_entry.router_id[MKTXPConfigKeys.ROUTERBOARD_NAME],
                                             MKTXPConfigKeys.ROUTERBOARD_ADDRESS: router_entry.router_id[MKTXPConfigKeys.ROUTERBOARD_ADDRESS],
                                             'server': key, 'count': value} for key, value in dhcp_lease_servers.items()]
-            
+
             # yield lease-per-server metrics
-            dhcp_lease_server_metrics = BaseCollector.gauge_collector('dhcp_lease_active_count', 
-                                                                        'Number of active leases per DHCP server', 
+            dhcp_lease_server_metrics = BaseCollector.gauge_collector('dhcp_lease_active_count',
+                                                                        'Number of active leases per DHCP server',
                                                                         dhcp_lease_servers_records, 'count', ['server'])
             yield dhcp_lease_server_metrics
 
             # active lease metrics
             dhcp_lease_labels.remove('expires_after')
             if router_entry.config_entry.dhcp_lease:
-                dhcp_lease_metrics_gauge = BaseCollector.gauge_collector('dhcp_lease_info', 'DHCP Active Leases', 
+                dhcp_lease_metrics_gauge = BaseCollector.gauge_collector('dhcp_lease_info', 'DHCP Active Leases',
                                                                         dhcp_lease_records, 'expires_after', dhcp_lease_labels)
                 yield dhcp_lease_metrics_gauge
 
@@ -56,4 +56,3 @@ class DHCPCollector(BaseCollector):
             #if router_entry.config_entry.dhcp_lease:
             #    dhcp_lease_metrics = BaseCollector.info_collector('dhcp_lease', 'DHCP Active Leases', dhcp_lease_records, dhcp_lease_labels)
             #    yield dhcp_lease_metrics
-

--- a/mktxp/collector/dhcp_collector.py
+++ b/mktxp/collector/dhcp_collector.py
@@ -25,7 +25,7 @@ class DHCPCollector(BaseCollector):
         if not router_entry.config_entry.dhcp:
             return
 
-        dhcp_lease_labels = ['active_address', 'address', 'mac_address', 'host_name', 'comment', 'server', 'expires_after', 'last_seen', 'client_id', 'active_mac_address']
+        dhcp_lease_labels = ['active_address', 'address', 'mac_address', 'host_name', 'comment', 'server', 'expires_after', 'client_id', 'active_mac_address']
         dhcp_lease_records = DHCPMetricsDataSource.metric_records(router_entry, metric_labels = dhcp_lease_labels)
         if dhcp_lease_records:
             # calculate number of leases per DHCP server

--- a/mktxp/datasource/dhcp_ds.py
+++ b/mktxp/datasource/dhcp_ds.py
@@ -18,11 +18,11 @@ from mktxp.utils.utils import parse_mkt_uptime
 
 class DHCPMetricsDataSource:
     ''' DHCP Metrics data provider
-    '''             
+    '''
     @staticmethod
     def metric_records(router_entry, *, metric_labels = None, add_router_id = True, dhcp_cache = True, translate = True, bound = False):
         if metric_labels is None or dhcp_cache:
-            metric_labels = ['host_name', 'comment', 'active_address', 'address', 'mac_address', 'server', 'expires_after']  
+            metric_labels = ['host_name', 'comment', 'active_address', 'address', 'mac_address', 'server', 'expires_after', 'last_seen', 'client_id', 'active_mac_address']
 
         if dhcp_cache and router_entry.dhcp_records:
             return router_entry.dhcp_records
@@ -35,21 +35,19 @@ class DHCPMetricsDataSource:
             # translation rules
             translation_table = {}
             if 'comment' in metric_labels:
-                translation_table['comment'] = lambda c: c if c else ''           
+                translation_table['comment'] = lambda c: c if c else ''
             if 'host_name' in metric_labels:
-                translation_table['host_name'] = lambda c: c if c else ''           
+                translation_table['host_name'] = lambda c: c if c else ''
             if 'expires_after' in metric_labels and translate:
-                translation_table['expires_after'] = lambda c: parse_mkt_uptime(c) if c else 0       
+                translation_table['expires_after'] = lambda c: parse_mkt_uptime(c) if c else 0
             if 'active_address' in metric_labels:
-                translation_table['active_address'] = lambda c: c if c else ''        
+                translation_table['active_address'] = lambda c: c if c else ''
 
             records = BaseDSProcessor.trimmed_records(router_entry, router_records = dhcp_lease_records, metric_labels = metric_labels, add_router_id = add_router_id, translation_table = translation_table)
             if dhcp_cache:
                 router_entry.dhcp_records = records
             return records
-            
+
         except Exception as exc:
             print(f'Error getting dhcp info from router{router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
             return None
-
-

--- a/mktxp/datasource/dhcp_ds.py
+++ b/mktxp/datasource/dhcp_ds.py
@@ -22,7 +22,7 @@ class DHCPMetricsDataSource:
     @staticmethod
     def metric_records(router_entry, *, metric_labels = None, add_router_id = True, dhcp_cache = True, translate = True, bound = False):
         if metric_labels is None or dhcp_cache:
-            metric_labels = ['host_name', 'comment', 'active_address', 'address', 'mac_address', 'server', 'expires_after', 'last_seen', 'client_id', 'active_mac_address']
+            metric_labels = ['host_name', 'comment', 'active_address', 'address', 'mac_address', 'server', 'expires_after', 'client_id', 'active_mac_address']
 
         if dhcp_cache and router_entry.dhcp_records:
             return router_entry.dhcp_records


### PR DESCRIPTION
This adds some currently missing metrics to the export. Especially `client-id` is important, because this is the [RFC4361)](https://www.rfc-editor.org/rfc/rfc4361) client id which is used by many clients (Ubuntu 22.04 with netplan uses this ID rather than the MAC by default).