### PR TITLE
NAT and mangle firewall metrics collection

### DIFF
--- a/mktxp/collector/firewall_collector.py
+++ b/mktxp/collector/firewall_collector.py
@@ -28,31 +28,55 @@ class FirewallCollector(BaseCollector):
 
         if router_entry.config_entry.firewall:
             # ~*~*~*~*~*~ IPv4 ~*~*~*~*~*~
-            firewall_filter_records = FirewallMetricsDataSource.metric_records_ipv4(router_entry, metric_labels = firewall_labels)   
+            firewall_filter_records = FirewallMetricsDataSource.metric_records_ipv4(router_entry, metric_labels = firewall_labels, filter_path='filter')
             if firewall_filter_records:           
                 metrics_records = [FirewallCollector.metric_record(router_entry, record) for record in firewall_filter_records]
                 firewall_filter_metrics = BaseCollector.counter_collector('firewall_filter', 'Total amount of bytes matched by firewall rules', metrics_records, 'bytes', ['name', 'log'])
                 yield firewall_filter_metrics
 
-            firewall_raw_records = FirewallMetricsDataSource.metric_records_ipv4(router_entry, metric_labels = firewall_labels, raw = True)        
+            firewall_raw_records = FirewallMetricsDataSource.metric_records_ipv4(router_entry, metric_labels = firewall_labels, filter_path='raw')
             if firewall_raw_records:      
                 metrics_records = [FirewallCollector.metric_record(router_entry, record) for record in firewall_raw_records]     
                 firewall_raw_metrics = BaseCollector.counter_collector('firewall_raw', 'Total amount of bytes matched by raw firewall rules', metrics_records, 'bytes', ['name', 'log'])
                 yield firewall_raw_metrics
 
+            filter_nat_records = FirewallMetricsDataSource.metric_records_ipv4(router_entry, metric_labels = firewall_labels, filter_path='nat')
+            if filter_nat_records:
+                metrics_records = [FirewallCollector.metric_record(router_entry, record) for record in filter_nat_records]
+                filter_nat_metrics = BaseCollector.counter_collector('firewall_nat', 'Total amount of bytes matched by NAT rules', metrics_records, 'bytes', ['name', 'log'])
+                yield filter_nat_metrics
+
+            filter_mangle_records = FirewallMetricsDataSource.metric_records_ipv4(router_entry, metric_labels = firewall_labels, filter_path='mangle')
+            if filter_mangle_records:
+                metrics_records = [FirewallCollector.metric_record(router_entry, record) for record in filter_mangle_records]
+                filter_mangle_metrics = BaseCollector.counter_collector('firewall_mangle', 'Total amount of bytes matched by Mangle rules', metrics_records, 'bytes', ['name', 'log'])
+                yield filter_mangle_metrics
+
         # ~*~*~*~*~*~ IPv6 ~*~*~*~*~*~
         if router_entry.config_entry.ipv6_firewall:
-            firewall_filter_records_ipv6 =  FirewallMetricsDataSource.metric_records_ipv6(router_entry, metric_labels = firewall_labels)
+            firewall_filter_records_ipv6 =  FirewallMetricsDataSource.metric_records_ipv6(router_entry, metric_labels = firewall_labels, filter_path='filter')
             if firewall_filter_records_ipv6:           
                 metrics_records_ipv6 = [FirewallCollector.metric_record(router_entry, record) for record in firewall_filter_records_ipv6]
                 firewall_filter_metrics_ipv6 = BaseCollector.counter_collector('firewall_filter_ipv6', 'Total amount of bytes matched by firewall rules (IPv6)', metrics_records_ipv6, 'bytes', ['name', 'log'])
                 yield firewall_filter_metrics_ipv6
 
-            firewall_raw_records_ipv6 = FirewallMetricsDataSource.metric_records_ipv6(router_entry, metric_labels = firewall_labels, raw = True)        
+            firewall_raw_records_ipv6 = FirewallMetricsDataSource.metric_records_ipv6(router_entry, metric_labels = firewall_labels, filter_path='raw')
             if firewall_raw_records_ipv6:      
                 metrics_records_ipv6 = [FirewallCollector.metric_record(router_entry, record) for record in firewall_raw_records_ipv6]     
                 firewall_raw_metrics_ipv6 = BaseCollector.counter_collector('firewall_raw_ipv6', 'Total amount of bytes matched by raw firewall rules (IPv6)', metrics_records_ipv6, 'bytes', ['name', 'log'])
                 yield firewall_raw_metrics_ipv6
+
+            filter_nat_records_ipv6 = FirewallMetricsDataSource.metric_records_ipv6(router_entry, metric_labels = firewall_labels, filter_path='nat')
+            if filter_nat_records_ipv6:
+                metrics_records_ipv6 = [FirewallCollector.metric_record(router_entry, record) for record in filter_nat_records_ipv6]
+                filter_nat_metrics_ipv6 = BaseCollector.counter_collector('firewall_nat_ipv6', 'Total amount of bytes matched by NAT rules (IPv6)', metrics_records_ipv6, 'bytes', ['name', 'log'])
+                yield filter_nat_metrics_ipv6
+
+            filter_mangle_records_ipv6 = FirewallMetricsDataSource.metric_records_ipv6(router_entry, metric_labels = firewall_labels, filter_path='mangle')
+            if filter_mangle_records_ipv6:
+                metrics_records_ipv6 = [FirewallCollector.metric_record(router_entry, record) for record in filter_mangle_records_ipv6]
+                filter_mangle_metrics_ipv6 = BaseCollector.counter_collector('firewall_mangle_ipv6', 'Total amount of bytes matched by Mangle rules (IPv6)', metrics_records_ipv6, 'bytes', ['name', 'log'])
+                yield filter_mangle_metrics_ipv6
 
     # Helpers
     @staticmethod

--- a/mktxp/datasource/firewall_ds.py
+++ b/mktxp/datasource/firewall_ds.py
@@ -40,11 +40,17 @@ class FirewallMetricsDataSource:
         return firewall_records
 
     @staticmethod
-    def metric_records_ipv4(router_entry, *, metric_labels=None, raw=False, matching_only=True):
+    def metric_records_ipv4(router_entry, *, metric_labels=None, matching_only=True, filter_path='filter'):
         if metric_labels is None:
             metric_labels = []
         try:
-            filter_path = '/ip/firewall/filter' if not raw else '/ip/firewall/raw'
+            filter_paths = {
+                'filter': '/ip/firewall/filter',
+                'raw': '/ip/firewall/raw',
+                'nat': '/ip/firewall/nat',
+                'mangle': '/ip/firewall/mangle'
+            }
+            filter_path = filter_paths[filter_path]
             firewall_records = FirewallMetricsDataSource._get_records(
                 router_entry,
                 filter_path,
@@ -60,10 +66,16 @@ class FirewallMetricsDataSource:
             return None
 
     @staticmethod
-    def metric_records_ipv6(router_entry, metric_labels=None, raw=False, matching_only=True):
+    def metric_records_ipv6(router_entry, metric_labels=None, matching_only=True, filter_path='filter'):
         metric_labels = metric_labels or []
         try:
-            filter_path = '/ipv6/firewall/filter' if not raw else '/ipv6/firewall/raw'
+            filter_paths = {
+                'filter': '/ipv6/firewall/filter',
+                'raw': '/ipv6/firewall/raw',
+                'nat': '/ipv6/firewall/nat',
+                'mangle': '/ipv6/firewall/mangle'
+            }
+            filter_path = filter_paths[filter_path]
             firewall_records = FirewallMetricsDataSource._get_records(
                 router_entry,
                 filter_path,


### PR DESCRIPTION
I noticed that the exporter tool currently doesn't support collecting metrics for NAT and mangle firewall rules. I've implemented support for this feature.
Related to akpw/mktxp#118