### PR TITLE
Revert "Retry connection without plain text authentication"

### DIFF
--- a/mktxp/flow/router_connection.py
+++ b/mktxp/flow/router_connection.py
@@ -78,12 +78,7 @@ class RouterAPIConnection:
             return
         try:
             print(f'Connecting to router {self.router_name}@{self.config_entry.hostname}')
-            try:
-                self.api = self.connection.get_api()
-            except:                
-                self.connection.plaintext_login = False
-                self.api = self.connection.get_api()
-
+            self.api = self.connection.get_api()
             self._set_connect_state(success = True, connect_time = connect_time)
         except (socket.error, socket.timeout, Exception) as exc:
             self._set_connect_state(success = False, connect_time = connect_time, exc = exc)


### PR DESCRIPTION
Reverts akpw/mktxp#114

Need to check the error, if error is "invalid user name or password" - then try to change the auth type.
Not every exception need to change the auth type.
Right now login is not working on new versions of ROS.