### PR TITLE
ipv6 connectivity by patching routeros-api/api_socket to the current version in git.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ LABEL org.opencontainers.image.source github.com/akpw/mktxp
 WORKDIR /mktxp
 COPY . .
 RUN pip install ./ && apk add nano
+
+# Patch routeros_api to support connection to IPv6 targets
+RUN apk add patch && patch /usr/local/lib/python3.12/site-packages/routeros_api/api_socket.py < deploy/routeros_api_ipv6_patch.diff
+
 EXPOSE 49090
 RUN addgroup -S mktxp && adduser -S mktxp -G mktxp
 USER mktxp

--- a/deploy/routeros_api_ipv6_patch.diff
+++ b/deploy/routeros_api_ipv6_patch.diff
@@ -1,0 +1,14 @@
+--- /usr/local/lib/python3.12/site-packages/routeros_api/api_socket.py
++++ api_socket.py
+@@ -9,10 +9,9 @@
+ EINTR = getattr(errno, 'EINTR', 4)
+
+ def get_socket(hostname, port, use_ssl=False, ssl_verify=True, ssl_verify_hostname=True, ssl_context=None, timeout=15.0):
+-    api_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+-    api_socket.settimeout(timeout)
+     while True:
+         try:
++            api_socket = socket.create_connection((hostname, port), timeout=timeout)
+             api_socket.connect((hostname, port))
+         except socket.error as e:
+             if e.args[0] != EINTR:


### PR DESCRIPTION
[IPv6] added support by patching the installed version 0.17.0 of socialwifi/routeros-api from a diff taken from git

This is one of two solutions, the other one is installing the correct git revision directly during the build process, but then we need to install git in the container -> larger size.

If you don't like the PR, delete it. :)