### PR TITLE
Fix wrong config item being used in user collector

### DIFF
--- a/mktxp/collector/user_collector.py
+++ b/mktxp/collector/user_collector.py
@@ -20,7 +20,7 @@ class UserCollector(BaseCollector):
     '''Active Users collector'''
     @staticmethod
     def collect(router_entry):
-        if not router_entry.config_entry.installed_packages:
+        if not router_entry.config_entry.user:
             return
 
         user_labels = ['name', 'when', 'address', 'via', 'group']


### PR DESCRIPTION
user collector wrongly uses installed_packages parameter to determine if logged user data is to be collected, instead of the user parameter.
