### PR TITLE
Add interface name labels to PoE output

### DIFF
--- a/mktxp/collector/poe_collector.py
+++ b/mktxp/collector/poe_collector.py
@@ -34,14 +34,14 @@ class POECollector(BaseCollector):
 
             for poe_record in poe_records:
                 if 'poe_out_voltage' in poe_record:
-                    poe_voltage_metrics = BaseCollector.gauge_collector('poe_out_voltage', 'POE Out Voltage', [poe_record, ], 'poe_out_voltage')
+                    poe_voltage_metrics = BaseCollector.gauge_collector('poe_out_voltage', 'POE Out Voltage', [poe_record, ], 'poe_out_voltage', ['name'])
                     yield poe_voltage_metrics
 
                 if 'poe_out_current' in poe_record:
-                    poe_current_metrics = BaseCollector.gauge_collector('poe_out_current', 'POE Out Current', [poe_record, ], 'poe_out_current')
+                    poe_current_metrics = BaseCollector.gauge_collector('poe_out_current', 'POE Out Current', [poe_record, ], 'poe_out_current', ['name'])
                     yield poe_current_metrics
 
                 if 'poe_out_power' in poe_record:
-                    poe_power_metrics = BaseCollector.gauge_collector('poe_out_power', 'POE Out Power', [poe_record, ], 'poe_out_power')
+                    poe_power_metrics = BaseCollector.gauge_collector('poe_out_power', 'POE Out Power', [poe_record, ], 'poe_out_power', ['name'])
                     yield poe_power_metrics
 


### PR DESCRIPTION
PoE monitor output currently doesn't use interface labeling:
![image](https://github.com/akpw/mktxp/assets/4690239/af89f598-134e-438b-88a9-c1470b62d269)

This patch corrects that to display the interface names:

![image](https://github.com/akpw/mktxp/assets/4690239/4175ebdc-b577-4b4a-90b5-56f56a84085e)
