### PR TITLE
fix bug when set verbose_mode to True in _mktxp.conf

### DIFF
--- a/mktxp/cli/options.py
+++ b/mktxp/cli/options.py
@@ -234,8 +234,8 @@ Selected metrics info can be printed on the command line. For more information, 
         quiet = not config_handler.system_entry.verbose_mode
         for command in commands:
             editor = run_cmd(command, quiet = quiet).rstrip()
-            if editor:
-                break                                  
+            if editor != 'nothing':
+                break
         return editor
 
 

--- a/mktxp/utils/utils.py
+++ b/mktxp/utils/utils.py
@@ -40,9 +40,6 @@ def temp_dir(quiet = True):
             if not quiet:
                 print ('Error while removing a tmp dir: {}'.format(e.args[0]))
 
-class CmdProcessingError(Exception):
-    pass
-
 def run_cmd(cmd, shell = False, quiet = False):
     ''' Runs shell commands in a separate process
     '''
@@ -51,7 +48,7 @@ def run_cmd(cmd, shell = False, quiet = False):
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell = shell)
     output = proc.communicate()[0].decode('utf-8')
     if proc.returncode != 0 and not quiet:
-        raise CmdProcessingError(output)
+        return 'nothing'
     return output
 
 def parse_mkt_uptime(time):


### PR DESCRIPTION
I face this issue when set `verbose_mode = True` in `_mktxp.conf`
```
Traceback (most recent call last):
  File "/home/ubuntu/mktxp/venv3.8.0/bin/mktxp", line 11, in <module>
    load_entry_point('mktxp==1.2.6', 'console_scripts', 'mktxp')()
  File "/home/ubuntu/mktxp/venv3.8.0/lib/python3.8/site-packages/mktxp/cli/dispatch.py", line 108, in main
    MKTXPDispatcher().dispatch()
  File "/home/ubuntu/mktxp/venv3.8.0/lib/python3.8/site-packages/mktxp/cli/dispatch.py", line 30, in dispatch
    args = self.option_parser.parse_options()
  File "/home/ubuntu/mktxp/venv3.8.0/lib/python3.8/site-packages/mktxp/cli/options.py", line 76, in parse_options
    self.parse_commands(commands_parser)
  File "/home/ubuntu/mktxp/venv3.8.0/lib/python3.8/site-packages/mktxp/cli/options.py", line 116, in parse_commands
    help = f"Command line editor to use ({self._system_editor()} by default)",
  File "/home/ubuntu/mktxp/venv3.8.0/lib/python3.8/site-packages/mktxp/cli/options.py", line 236, in _system_editor
    editor = run_cmd(command, quiet = quiet).rstrip()
  File "/home/ubuntu/mktxp/venv3.8.0/lib/python3.8/site-packages/mktxp/utils/utils.py", line 58, in run_cmd
    raise CmdProcessingError(output)
mktxp.utils.utils.CmdProcessingError
```

After debugging, I found out that my server does not have nano by default, it will lead to CmdProcessingError(output)