### PR TITLE
ci: new image build workflow

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,83 +1,70 @@
----
-# template source: https://github.com/bretfisher/docker-build-workflow/blob/main/templates/call-docker-build.yaml
 name: Docker Build
 
 on:
   push:
-    branches:
-      - main
-    # don't rebuild image if someone only edited unrelated files
+    branches: ['**']
+    tags: ['**']
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
   pull_request:
-    # don't rebuild image if someone only edited unrelated files
+    types: [opened, reopened]
+    branches: [main]
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+  release:
+    types: [published]
 
 jobs:
   call-docker-build:
     name: Call Docker Build
-
-    uses: bretfisher/docker-build-workflow/.github/workflows/reusable-docker-build.yaml@2f9fdc0325196df9f11bfe4263e277793e648922
-
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write # needed to push docker image to ghcr.io
-      pull-requests: write # needed to create and update comments in PRs
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    secrets:
-      # Only needed if with:dockerhub-enable is true below
-      # https://hub.docker.com/settings/security
-      dockerhub-username: ""
-      dockerhub-token: ""
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    with:
-      ### REQUIRED
-      ### ENABLE ONE OR BOTH REGISTRIES
-      ### tell docker where to push.
-      ### NOTE if Docker Hub is set to true, you must set secrets above and also add account/repo/tags below
-      dockerhub-enable: false
-      ghcr-enable: true
+      - name: Collect Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          flavor: latest=false
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch
 
-      ### A list of the account/repo names for docker build. List should match what's enabled above
-      ### defaults to:
-      image-names: |
-        name=ghcr.io/${{ github.repository }}
-      #  name=${{ github.repository }},enable=false
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64
 
-      ### set rules for tagging images, based on special action syntax:
-      ### https://github.com/docker/metadata-action#tags-input
-      ### defaults to:
-      tag-rules: |
-        type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-        type=raw,value=stable-{{date 'YYYYMMDDHHmmss'}},enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-        type=raw,value=gha-${{ github.run_id }}
-        type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
-        type=semver,pattern=v{{major}}.{{minor}}
-        type=semver,pattern=v{{major}}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      ### path to where docker should copy files into image
-      ### defaults to root of repository (.)
-      # context: .
-
-      ### Dockerfile alternate name. Default is Dockerfile (relative to context path)
-      # file: Containerfile
-
-      ### build stage to target, defaults to empty, which builds to last stage in Dockerfile
-      # target:
-
-      ### platforms to build for
-      ### defaults to linux/amd64
-      ### other options: linux/amd64,linux/arm64,linux/arm/v7
-      platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/386
-
-      ### Create a PR comment with image tags and labels
-      ### defaults to true
-      # comment-enable: false
-
-      # Additionals parameters
-      # (cf https://github.com/marketplace/actions/docker-metadata-action#flavor-input)
-      flavor-rules: |
-        latest=auto
+      - name: Build and publish Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-to: type=gha,mode=min
+          cache-from: type=gha


### PR DESCRIPTION
closes https://github.com/akpw/mktxp/issues/185

- add semver tags to the images, matching the semver tags in git
- migrate off the workflow template, which had deprecated commands and NodeJS versions