### PR TITLE
Add more SFP/interface statistics & ability to print

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The default configuration file comes with a sample configuration, making it easy
 
     poe = True                      # POE metrics
     monitor = True                  # Interface monitor metrics
+    monitor_unplugged = False       # Interface monitor metrics for unplugged SFP/SFP+ ports
     netwatch = True                 # Netwatch metrics
     public_ip = True                # Public IP metrics
     wireless = True                 # WLAN general metrics

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The default configuration file comes with a sample configuration, making it easy
 
     poe = True                      # POE metrics
     monitor = True                  # Interface monitor metrics
-    monitor_unplugged = False       # Interface monitor metrics for unplugged SFP/SFP+ ports
+    monitor_sfp_unplugged = False   # Interface monitor metrics for unplugged SFP/SFP+ ports
     netwatch = True                 # Netwatch metrics
     public_ip = True                # Public IP metrics
     wireless = True                 # WLAN general metrics

--- a/deploy/kubernetes/secret.yaml
+++ b/deploy/kubernetes/secret.yaml
@@ -92,6 +92,7 @@ stringData:
 
             poe = True                      # POE metrics
             monitor = True                  # Interface monitor metrics
+            monitor_unplugged = False       # Interface monitor metrics for unplugged SFP/SFP+ ports
             netwatch = True                 # Netwatch metrics
             public_ip = True                # Public IP metrics
             wireless = True                 # WLAN general metrics

--- a/deploy/kubernetes/secret.yaml
+++ b/deploy/kubernetes/secret.yaml
@@ -5,7 +5,7 @@ metadata:
 type: Opaque
 stringData:
     _mktxp.conf: |
-        ## Copyright (c) 2020 Arseniy Kuznetsov
+        ## Copyright (c) 2024 Arseniy Kuznetsov
         ##
         ## This program is free software; you can redistribute it and/or
         ## modify it under the terms of the GNU General Public License
@@ -39,7 +39,7 @@ stringData:
 
             compact_default_conf_values = False  # Compact mktxp.conf, so only specific values are kept on the individual routers' level
     mktxp.conf: |
-        ## Copyright (c) 2020 Arseniy Kuznetsov
+        ## Copyright (c) 2024 Arseniy Kuznetsov
         ##
         ## This program is free software; you can redistribute it and/or
         ## modify it under the terms of the GNU General Public License

--- a/deploy/kubernetes/secret.yaml
+++ b/deploy/kubernetes/secret.yaml
@@ -92,7 +92,7 @@ stringData:
 
             poe = True                      # POE metrics
             monitor = True                  # Interface monitor metrics
-            monitor_unplugged = False       # Interface monitor metrics for unplugged SFP/SFP+ ports
+            monitor_sfp_unplugged = False   # Interface monitor metrics for unplugged SFP/SFP+ ports
             netwatch = True                 # Netwatch metrics
             public_ip = True                # Public IP metrics
             wireless = True                 # WLAN general metrics

--- a/mktxp/cli/checks/chk_pv.py
+++ b/mktxp/cli/checks/chk_pv.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/cli/config/_mktxp.conf
+++ b/mktxp/cli/config/_mktxp.conf
@@ -1,4 +1,4 @@
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/cli/config/config.py
+++ b/mktxp/cli/config/config.py
@@ -1,5 +1,5 @@
 # coding=utf8
-# Copyright (c) 2020 Arseniy Kuznetsov
+# Copyright (c) 2024 Arseniy Kuznetsov
 ##
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/mktxp/cli/config/config.py
+++ b/mktxp/cli/config/config.py
@@ -89,7 +89,7 @@ class MKTXPConfigKeys:
     FE_IPV6_NEIGHBOR_KEY = 'ipv6_neighbor'
 
     FE_MONITOR_KEY = 'monitor'
-    FE_MONITOR_UNPLUGGED_KEY = 'monitor_unplugged'
+    FE_MONITOR_SFP_UNPLUGGED_KEY = 'monitor_sfp_unplugged'
     FE_WIRELESS_KEY = 'wireless'
     FE_WIRELESS_CLIENTS_KEY = 'wireless_clients'
     FE_CAPSMAN_KEY = 'capsman'
@@ -163,7 +163,7 @@ class MKTXPConfigKeys:
 
     BOOLEAN_KEYS_NO = {ENABLED_KEY, SSL_KEY, NO_SSL_CERTIFICATE, FE_CHECK_FOR_UPDATES, FE_KID_CONTROL_DEVICE, FE_KID_CONTROL_DYNAMIC,
                        SSL_CERTIFICATE_VERIFY, FE_IPV6_ROUTE_KEY, FE_IPV6_DHCP_POOL_KEY, FE_IPV6_FIREWALL_KEY, FE_IPV6_NEIGHBOR_KEY, FE_CONNECTION_STATS_KEY, FE_BGP_KEY,
-                       FE_IPSEC_KEY, FE_LTE_KEY, FE_MONITOR_UNPLUGGED_KEY, FE_SWITCH_PORT_KEY, FE_ROUTING_STATS_KEY, FE_CERTIFICATE_KEY}
+                       FE_IPSEC_KEY, FE_LTE_KEY, FE_MONITOR_SFP_UNPLUGGED_KEY, FE_SWITCH_PORT_KEY, FE_ROUTING_STATS_KEY, FE_CERTIFICATE_KEY}
 
     # Feature keys enabled by default
     BOOLEAN_KEYS_YES = {PLAINTEXT_LOGIN_KEY, FE_DHCP_KEY, FE_PACKAGE_KEY, FE_DHCP_LEASE_KEY, FE_IP_CONNECTIONS_KEY, FE_INTERFACE_KEY, 
@@ -190,7 +190,7 @@ class ConfigEntry:
                                                        MKTXPConfigKeys.USER_KEY, MKTXPConfigKeys.PASSWD_KEY,
                                                        MKTXPConfigKeys.SSL_KEY, MKTXPConfigKeys.NO_SSL_CERTIFICATE, MKTXPConfigKeys.SSL_CERTIFICATE_VERIFY, MKTXPConfigKeys.PLAINTEXT_LOGIN_KEY,
                                                        MKTXPConfigKeys.FE_DHCP_KEY, MKTXPConfigKeys.FE_PACKAGE_KEY, MKTXPConfigKeys.FE_DHCP_LEASE_KEY, MKTXPConfigKeys.FE_INTERFACE_KEY,
-                                                       MKTXPConfigKeys.FE_MONITOR_KEY, MKTXPConfigKeys.FE_MONITOR_UNPLUGGED_KEY, MKTXPConfigKeys.FE_WIRELESS_KEY, MKTXPConfigKeys.FE_WIRELESS_CLIENTS_KEY,
+                                                       MKTXPConfigKeys.FE_MONITOR_KEY, MKTXPConfigKeys.FE_MONITOR_SFP_UNPLUGGED_KEY, MKTXPConfigKeys.FE_WIRELESS_KEY, MKTXPConfigKeys.FE_WIRELESS_CLIENTS_KEY,
                                                        MKTXPConfigKeys.FE_IP_CONNECTIONS_KEY, MKTXPConfigKeys.FE_CONNECTION_STATS_KEY, MKTXPConfigKeys.FE_CAPSMAN_KEY, MKTXPConfigKeys.FE_CAPSMAN_CLIENTS_KEY, MKTXPConfigKeys.FE_POE_KEY, 
                                                        MKTXPConfigKeys.FE_NETWATCH_KEY, MKTXPConfigKeys.MKTXP_USE_COMMENTS_OVER_NAMES, MKTXPConfigKeys.FE_PUBLIC_IP_KEY,
                                                        MKTXPConfigKeys.FE_ROUTE_KEY, MKTXPConfigKeys.FE_DHCP_POOL_KEY, MKTXPConfigKeys.FE_FIREWALL_KEY, MKTXPConfigKeys.FE_NEIGHBOR_KEY,

--- a/mktxp/cli/config/config.py
+++ b/mktxp/cli/config/config.py
@@ -87,6 +87,7 @@ class MKTXPConfigKeys:
     FE_IPV6_NEIGHBOR_KEY = 'ipv6_neighbor'
 
     FE_MONITOR_KEY = 'monitor'
+    FE_MONITOR_UNPLUGGED_KEY = 'monitor_unplugged'
     FE_WIRELESS_KEY = 'wireless'
     FE_WIRELESS_CLIENTS_KEY = 'wireless_clients'
     FE_CAPSMAN_KEY = 'capsman'
@@ -157,7 +158,7 @@ class MKTXPConfigKeys:
 
     BOOLEAN_KEYS_NO = {ENABLED_KEY, SSL_KEY, NO_SSL_CERTIFICATE, FE_CHECK_FOR_UPDATES, FE_KID_CONTROL_DEVICE, FE_KID_CONTROL_DYNAMIC,
                        SSL_CERTIFICATE_VERIFY, FE_IPV6_ROUTE_KEY, FE_IPV6_DHCP_POOL_KEY, FE_IPV6_FIREWALL_KEY, FE_IPV6_NEIGHBOR_KEY, FE_CONNECTION_STATS_KEY, FE_BGP_KEY,
-                       FE_IPSEC_KEY, FE_LTE_KEY, FE_SWITCH_PORT_KEY}
+                       FE_IPSEC_KEY, FE_LTE_KEY, FE_MONITOR_UNPLUGGED_KEY, FE_SWITCH_PORT_KEY}
 
     # Feature keys enabled by default
     BOOLEAN_KEYS_YES = {PLAINTEXT_LOGIN_KEY, FE_DHCP_KEY, FE_PACKAGE_KEY, FE_DHCP_LEASE_KEY, FE_IP_CONNECTIONS_KEY, FE_INTERFACE_KEY, 
@@ -184,7 +185,7 @@ class ConfigEntry:
                                                        MKTXPConfigKeys.USER_KEY, MKTXPConfigKeys.PASSWD_KEY,
                                                        MKTXPConfigKeys.SSL_KEY, MKTXPConfigKeys.NO_SSL_CERTIFICATE, MKTXPConfigKeys.SSL_CERTIFICATE_VERIFY, MKTXPConfigKeys.PLAINTEXT_LOGIN_KEY,
                                                        MKTXPConfigKeys.FE_DHCP_KEY, MKTXPConfigKeys.FE_PACKAGE_KEY, MKTXPConfigKeys.FE_DHCP_LEASE_KEY, MKTXPConfigKeys.FE_INTERFACE_KEY,
-                                                       MKTXPConfigKeys.FE_MONITOR_KEY, MKTXPConfigKeys.FE_WIRELESS_KEY, MKTXPConfigKeys.FE_WIRELESS_CLIENTS_KEY,
+                                                       MKTXPConfigKeys.FE_MONITOR_KEY, MKTXPConfigKeys.FE_MONITOR_UNPLUGGED_KEY, MKTXPConfigKeys.FE_WIRELESS_KEY, MKTXPConfigKeys.FE_WIRELESS_CLIENTS_KEY,
                                                        MKTXPConfigKeys.FE_IP_CONNECTIONS_KEY, MKTXPConfigKeys.FE_CONNECTION_STATS_KEY, MKTXPConfigKeys.FE_CAPSMAN_KEY, MKTXPConfigKeys.FE_CAPSMAN_CLIENTS_KEY, MKTXPConfigKeys.FE_POE_KEY, 
                                                        MKTXPConfigKeys.FE_NETWATCH_KEY, MKTXPConfigKeys.MKTXP_USE_COMMENTS_OVER_NAMES, MKTXPConfigKeys.FE_PUBLIC_IP_KEY,
                                                        MKTXPConfigKeys.FE_ROUTE_KEY, MKTXPConfigKeys.FE_DHCP_POOL_KEY, MKTXPConfigKeys.FE_FIREWALL_KEY, MKTXPConfigKeys.FE_NEIGHBOR_KEY,

--- a/mktxp/cli/config/mktxp.conf
+++ b/mktxp/cli/config/mktxp.conf
@@ -1,4 +1,4 @@
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/cli/config/mktxp.conf
+++ b/mktxp/cli/config/mktxp.conf
@@ -51,7 +51,7 @@
 
     poe = True                      # POE metrics
     monitor = True                  # Interface monitor metrics
-    monitor_unplugged = False       # Interface monitor metrics for unplugged SFP/SFP+ ports
+    monitor_sfp_unplugged = False   # Interface monitor metrics for unplugged SFP/SFP+ ports
     netwatch = True                 # Netwatch metrics
     public_ip = True                # Public IP metrics
     wireless = True                 # WLAN general metrics

--- a/mktxp/cli/config/mktxp.conf
+++ b/mktxp/cli/config/mktxp.conf
@@ -51,6 +51,7 @@
 
     poe = True                      # POE metrics
     monitor = True                  # Interface monitor metrics
+    monitor_unplugged = False       # Interface monitor metrics for unplugged SFP/SFP+ ports
     netwatch = True                 # Netwatch metrics
     public_ip = True                # Public IP metrics
     wireless = True                 # WLAN general metrics

--- a/mktxp/cli/dispatch.py
+++ b/mktxp/cli/dispatch.py
@@ -101,6 +101,9 @@ class MKTXPDispatcher:
         elif args['conn_stats']:
             OutputProcessor.conn_stats(args['entry_name'])
 
+        elif args['interface_stats']:
+            OutputProcessor.interface_stats(args['entry_name'])
+
         else:
             print("Select metric option(s) to print out, or run 'mktxp print -h' to find out more")
 

--- a/mktxp/cli/dispatch.py
+++ b/mktxp/cli/dispatch.py
@@ -1,6 +1,6 @@
 #!.usr/bin/env python
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/cli/options.py
+++ b/mktxp/cli/options.py
@@ -149,6 +149,10 @@ Selected metrics info can be printed on the command line. For more information, 
                 help = "IP connections stats",
                 action = 'store_true')
 
+        optional_args_group.add_argument('-if', '--interface_stats', dest='interface_stats',
+                help = "Interface stats",
+                action = 'store_true')
+
 
     # Options checking
     def _check_args(self, args, parser):

--- a/mktxp/cli/options.py
+++ b/mktxp/cli/options.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/cli/output/capsman_out.py
+++ b/mktxp/cli/output/capsman_out.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/cli/output/conn_stats_out.py
+++ b/mktxp/cli/output/conn_stats_out.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/cli/output/dhcp_out.py
+++ b/mktxp/cli/output/dhcp_out.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/cli/output/interface_stats_out.py
+++ b/mktxp/cli/output/interface_stats_out.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2024 The mktxp Project Contributors
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/cli/output/interface_stats_out.py
+++ b/mktxp/cli/output/interface_stats_out.py
@@ -22,7 +22,7 @@ class InterfaceStatsOutput:
     @staticmethod
     def clients_summary(router_entry):
         monitor_labels = ['status', 'rate', 'full_duplex', 'name', 'sfp_temperature', 'sfp_module_present', 'sfp_wavelength', 'sfp_tx_power', 'sfp_rx_power', 'sfp_supply_voltage', 'sfp_tx_bias_current', 'sfp_rx_loss', 'sfp_tx_fault']
-        monitor_records = InterfaceMonitorMetricsDataSource.metric_records(router_entry, metric_labels = monitor_labels, add_router_id = False, running_only = not router_entry.config_entry.monitor_unplugged)
+        monitor_records = InterfaceMonitorMetricsDataSource.metric_records(router_entry, metric_labels = monitor_labels, add_router_id = False, running_only = not router_entry.config_entry.monitor_sfp_unplugged)
         if not monitor_records:
             print('No monitor stats records')
             return

--- a/mktxp/cli/output/interface_stats_out.py
+++ b/mktxp/cli/output/interface_stats_out.py
@@ -1,0 +1,42 @@
+# coding=utf8
+## Copyright (c) 2024 Patrick Plenefisch
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+
+from mktxp.flow.processor.output import BaseOutputProcessor
+from mktxp.datasource.interface_ds import InterfaceMonitorMetricsDataSource
+
+
+class InterfaceStatsOutput:
+    ''' Interface Stats Output
+    '''
+    @staticmethod
+    def clients_summary(router_entry):
+        monitor_labels = ['status', 'rate', 'full_duplex', 'name', 'sfp_temperature', 'sfp_module_present', 'sfp_wavelength', 'sfp_tx_power', 'sfp_rx_power', 'sfp_supply_voltage', 'sfp_tx_bias_current']
+        monitor_records = InterfaceMonitorMetricsDataSource.metric_records(router_entry, metric_labels = monitor_labels, add_router_id = False, running_only = not router_entry.config_entry.monitor_unplugged)
+        if not monitor_records:
+            print('No monitor stats records')
+            return
+
+        output_records_cnt = 0
+        output_entry = BaseOutputProcessor.OutputInterfaceStatsEntry
+        output_table = BaseOutputProcessor.output_table(output_entry)
+
+        for record in monitor_records:
+            output_table.add_row(output_entry(**record))
+            output_table.add_row(output_entry())
+            output_records_cnt += 1
+
+        print (output_table.draw())
+
+        print(f'Total interfaces: {output_records_cnt}')
+

--- a/mktxp/cli/output/interface_stats_out.py
+++ b/mktxp/cli/output/interface_stats_out.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2024 Patrick Plenefisch
+## Copyright (c) 2024 The mktxp Project Contributors
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/cli/output/interface_stats_out.py
+++ b/mktxp/cli/output/interface_stats_out.py
@@ -21,7 +21,7 @@ class InterfaceStatsOutput:
     '''
     @staticmethod
     def clients_summary(router_entry):
-        monitor_labels = ['status', 'rate', 'full_duplex', 'name', 'sfp_temperature', 'sfp_module_present', 'sfp_wavelength', 'sfp_tx_power', 'sfp_rx_power', 'sfp_supply_voltage', 'sfp_tx_bias_current']
+        monitor_labels = ['status', 'rate', 'full_duplex', 'name', 'sfp_temperature', 'sfp_module_present', 'sfp_wavelength', 'sfp_tx_power', 'sfp_rx_power', 'sfp_supply_voltage', 'sfp_tx_bias_current', 'sfp_rx_loss', 'sfp_tx_fault']
         monitor_records = InterfaceMonitorMetricsDataSource.metric_records(router_entry, metric_labels = monitor_labels, add_router_id = False, running_only = not router_entry.config_entry.monitor_unplugged)
         if not monitor_records:
             print('No monitor stats records')

--- a/mktxp/cli/output/wifi_out.py
+++ b/mktxp/cli/output/wifi_out.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/bandwidth_collector.py
+++ b/mktxp/collector/bandwidth_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/base_collector.py
+++ b/mktxp/collector/base_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/bgp_collector.py
+++ b/mktxp/collector/bgp_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/capsman_collector.py
+++ b/mktxp/collector/capsman_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/certificate_collector.py
+++ b/mktxp/collector/certificate_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/connection_collector.py
+++ b/mktxp/collector/connection_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/dhcp_collector.py
+++ b/mktxp/collector/dhcp_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/firewall_collector.py
+++ b/mktxp/collector/firewall_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/health_collector.py
+++ b/mktxp/collector/health_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/identity_collector.py
+++ b/mktxp/collector/identity_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/interface_collector.py
+++ b/mktxp/collector/interface_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/ipsec_collector.py
+++ b/mktxp/collector/ipsec_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/kid_control_device_collector.py
+++ b/mktxp/collector/kid_control_device_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/lte_collector.py
+++ b/mktxp/collector/lte_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/mktxp_collector.py
+++ b/mktxp/collector/mktxp_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/monitor_collector.py
+++ b/mktxp/collector/monitor_collector.py
@@ -37,7 +37,7 @@ class MonitorCollector(BaseCollector):
                 'sfp_temperature': lambda value: value if value else '0'
                 }
         monitor_records = InterfaceMonitorMetricsDataSource.metric_records(router_entry, metric_labels = monitor_labels, 
-                                                                                        translation_table=translation_table, include_comments = True, running_only = not router_entry.config_entry.monitor_unplugged)
+                                                                                        translation_table=translation_table, include_comments = True, running_only = not router_entry.config_entry.monitor_sfp_unplugged)
         if monitor_records:
             monitor_status_metrics = BaseCollector.gauge_collector('interface_status', 'Current interface link status', monitor_records, 'status', ['name'])
             yield monitor_status_metrics

--- a/mktxp/collector/monitor_collector.py
+++ b/mktxp/collector/monitor_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/monitor_collector.py
+++ b/mktxp/collector/monitor_collector.py
@@ -25,13 +25,15 @@ class MonitorCollector(BaseCollector):
         if not router_entry.config_entry.monitor:
             return
 
-        monitor_labels = ['status', 'rate', 'full_duplex', 'name', 'sfp_temperature', 'sfp_module_present', 'sfp_wavelength', 'sfp_tx_power', 'sfp_rx_power', 'sfp_supply_voltage', 'sfp_tx_bias_current']
+        monitor_labels = ['status', 'rate', 'full_duplex', 'name', 'sfp_temperature', 'sfp_module_present', 'sfp_wavelength', 'sfp_tx_power', 'sfp_rx_power', 'sfp_supply_voltage', 'sfp_tx_bias_current', 'sfp_rx_loss', 'sfp_tx_fault']
         translation_table = {
                 'status': lambda value: '1' if value=='link-ok' else '0',
                 'rate': lambda value: MonitorCollector._rates(value) if value else '0',
                 'full_duplex': lambda value: '1' if value=='true' else '0',
                 'name': lambda value: value if value else '',
                 'sfp_module_present': lambda value: '1' if value=='true' else '0',
+                'sfp_rx_loss': lambda value: '1' if value=='true' else '0',
+                'sfp_tx_fault': lambda value: '1' if value=='true' else '0',
                 'sfp_temperature': lambda value: value if value else '0'
                 }
         monitor_records = InterfaceMonitorMetricsDataSource.metric_records(router_entry, metric_labels = monitor_labels, 
@@ -55,6 +57,10 @@ class MonitorCollector(BaseCollector):
                 yield BaseCollector.gauge_collector('interface_sfp_wavelength', 'Current SFP Wavelength',sfp_metrics, 'sfp_wavelength', ['name'])
                 yield BaseCollector.gauge_collector('interface_sfp_tx_power', 'Current SFP TX Power', sfp_metrics, 'sfp_tx_power', ['name'])
                 yield BaseCollector.gauge_collector('interface_sfp_rx_power', 'Current SFP RX Power', sfp_metrics, 'sfp_rx_power', ['name'])
+                yield BaseCollector.gauge_collector('interface_sfp_supply_voltage', 'Current SFP Supply Voltage', sfp_metrics, 'sfp_supply_voltage', ['name'])
+                yield BaseCollector.gauge_collector('interface_sfp_tx_bias_current', 'Current SFP TX Bias Current', sfp_metrics, 'sfp_tx_bias_current', ['name'])
+                yield BaseCollector.gauge_collector('interface_sfp_tx_fault', 'Current SFP Suffering TX fault', sfp_metrics, 'sfp_tx_fault', ['name'])
+                yield BaseCollector.gauge_collector('interface_sfp_rx_loss', 'Current SFP Suffering RX loss', sfp_metrics, 'sfp_rx_loss', ['name'])
 
 
     @staticmethod

--- a/mktxp/collector/monitor_collector.py
+++ b/mktxp/collector/monitor_collector.py
@@ -25,7 +25,7 @@ class MonitorCollector(BaseCollector):
         if not router_entry.config_entry.monitor:
             return
 
-        monitor_labels = ['status', 'rate', 'full_duplex', 'name', 'sfp_temperature', 'sfp_module_present', 'sfp_wavelength', 'sfp_tx_power', 'sfp_rx_power']
+        monitor_labels = ['status', 'rate', 'full_duplex', 'name', 'sfp_temperature', 'sfp_module_present', 'sfp_wavelength', 'sfp_tx_power', 'sfp_rx_power', 'sfp_supply_voltage', 'sfp_tx_bias_current']
         translation_table = {
                 'status': lambda value: '1' if value=='link-ok' else '0',
                 'rate': lambda value: MonitorCollector._rates(value) if value else '0',
@@ -35,7 +35,7 @@ class MonitorCollector(BaseCollector):
                 'sfp_temperature': lambda value: value if value else '0'
                 }
         monitor_records = InterfaceMonitorMetricsDataSource.metric_records(router_entry, metric_labels = monitor_labels, 
-                                                                                        translation_table=translation_table, include_comments = True)   
+                                                                                        translation_table=translation_table, include_comments = True, running_only = not router_entry.config_entry.monitor_unplugged)
         if monitor_records:
             monitor_status_metrics = BaseCollector.gauge_collector('interface_status', 'Current interface link status', monitor_records, 'status', ['name'])
             yield monitor_status_metrics

--- a/mktxp/collector/neighbor_collector.py
+++ b/mktxp/collector/neighbor_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-# Copyright (c) 2020 Arseniy Kuznetsov
+# Copyright (c) 2024 Arseniy Kuznetsov
 ##
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/mktxp/collector/netwatch_collector.py
+++ b/mktxp/collector/netwatch_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/package_collector.py
+++ b/mktxp/collector/package_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/poe_collector.py
+++ b/mktxp/collector/poe_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/pool_collector.py
+++ b/mktxp/collector/pool_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/public_ip_collector.py
+++ b/mktxp/collector/public_ip_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/queue_collector.py
+++ b/mktxp/collector/queue_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/resource_collector.py
+++ b/mktxp/collector/resource_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/route_collector.py
+++ b/mktxp/collector/route_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/routing_stats_collector.py
+++ b/mktxp/collector/routing_stats_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/switch_collector.py
+++ b/mktxp/collector/switch_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/user_collector.py
+++ b/mktxp/collector/user_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/collector/wlan_collector.py
+++ b/mktxp/collector/wlan_collector.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/base_ds.py
+++ b/mktxp/datasource/base_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/bgp_ds.py
+++ b/mktxp/datasource/bgp_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/capsman_ds.py
+++ b/mktxp/datasource/capsman_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/certificate_ds.py
+++ b/mktxp/datasource/certificate_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/connection_ds.py
+++ b/mktxp/datasource/connection_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/dhcp_ds.py
+++ b/mktxp/datasource/dhcp_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/firewall_ds.py
+++ b/mktxp/datasource/firewall_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-# Copyright (c) 2020 Arseniy Kuznetsov
+# Copyright (c) 2024 Arseniy Kuznetsov
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/health_ds.py
+++ b/mktxp/datasource/health_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/identity_ds.py
+++ b/mktxp/datasource/identity_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/interface_ds.py
+++ b/mktxp/datasource/interface_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/interface_ds.py
+++ b/mktxp/datasource/interface_ds.py
@@ -48,7 +48,7 @@ class InterfaceMonitorMetricsDataSource:
     ''' Interface Monitor Metrics data provider
     '''
     @staticmethod
-    def metric_records(router_entry, *, metric_labels = None, translation_table = None, kind = 'ethernet', include_comments = False, running_only = True):
+    def metric_records(router_entry, *, metric_labels = None, translation_table = None, kind = 'ethernet', include_comments = False, running_only = True, add_router_id = True):
         if metric_labels is None:
             metric_labels = []
 
@@ -80,7 +80,7 @@ class InterfaceMonitorMetricsDataSource:
             for interface_monitor_record in interface_monitor_records:
                 if 'registered-peers' in interface_monitor_record:
                     interface_monitor_record['registered-clients'] = interface_monitor_record['registered-peers']
-            return BaseDSProcessor.trimmed_records(router_entry, router_records = interface_monitor_records, metric_labels = metric_labels, translation_table=translation_table)
+            return BaseDSProcessor.trimmed_records(router_entry, router_records = interface_monitor_records, metric_labels = metric_labels, translation_table=translation_table, add_router_id = add_router_id)
         except Exception as exc:
             print(f'Error getting {kind} interface monitor info from router {router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}')
             return None

--- a/mktxp/datasource/ipsec_ds.py
+++ b/mktxp/datasource/ipsec_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/kid_control_device_ds.py
+++ b/mktxp/datasource/kid_control_device_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/mktxp_ds.py
+++ b/mktxp/datasource/mktxp_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/neighbor_ds.py
+++ b/mktxp/datasource/neighbor_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-# Copyright (c) 2020 Arseniy Kuznetsov
+# Copyright (c) 2024 Arseniy Kuznetsov
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/netwatch_ds.py
+++ b/mktxp/datasource/netwatch_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/package_ds.py
+++ b/mktxp/datasource/package_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/poe_ds.py
+++ b/mktxp/datasource/poe_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/pool_ds.py
+++ b/mktxp/datasource/pool_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/public_ip_ds.py
+++ b/mktxp/datasource/public_ip_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/queue_ds.py
+++ b/mktxp/datasource/queue_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/route_ds.py
+++ b/mktxp/datasource/route_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/routerboard_ds.py
+++ b/mktxp/datasource/routerboard_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/routing_stats_ds.py
+++ b/mktxp/datasource/routing_stats_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/switch_ds.py
+++ b/mktxp/datasource/switch_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/system_resource_ds.py
+++ b/mktxp/datasource/system_resource_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/user_ds.py
+++ b/mktxp/datasource/user_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/datasource/wireless_ds.py
+++ b/mktxp/datasource/wireless_ds.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/flow/collector_handler.py
+++ b/mktxp/flow/collector_handler.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/flow/collector_registry.py
+++ b/mktxp/flow/collector_registry.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/flow/processor/base_proc.py
+++ b/mktxp/flow/processor/base_proc.py
@@ -25,6 +25,7 @@ from mktxp.cli.output.capsman_out import CapsmanOutput
 from mktxp.cli.output.wifi_out import WirelessOutput
 from mktxp.cli.output.dhcp_out import DHCPOutput
 from mktxp.cli.output.conn_stats_out import ConnectionsStatsOutput
+from mktxp.cli.output.interface_stats_out import InterfaceStatsOutput
 
 from waitress import serve
 
@@ -65,5 +66,11 @@ class OutputProcessor:
         router_entry = RouterEntriesHandler.router_entry(entry_name)
         if router_entry:
             ConnectionsStatsOutput.clients_summary(router_entry)
+
+    @staticmethod
+    def interface_stats(entry_name):
+        router_entry = RouterEntriesHandler.router_entry(entry_name)
+        if router_entry:
+            InterfaceStatsOutput.clients_summary(router_entry)
 
             

--- a/mktxp/flow/processor/base_proc.py
+++ b/mktxp/flow/processor/base_proc.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/flow/processor/output.py
+++ b/mktxp/flow/processor/output.py
@@ -39,6 +39,9 @@ class BaseOutputProcessor:
     OutputConnStatsEntry = namedtuple('OutputConnStatsEntry', ['dhcp_name', 'src_address', 'connection_count', 'dst_addresses'])
     OutputConnStatsEntry.__new__.__defaults__ = ('',) * len(OutputConnStatsEntry._fields)
 
+    OutputInterfaceStatsEntry = namedtuple('InterfaceStatsEntry', ['name', 'status', 'rate', 'full_duplex', 'sfp_module_present', 'sfp_temperature', 'sfp_wavelength', 'sfp_tx_power', 'sfp_rx_power', 'sfp_supply_voltage', 'sfp_tx_bias_current'])
+    OutputInterfaceStatsEntry.__new__.__defaults__ = ('',) * len(OutputInterfaceStatsEntry._fields)
+
 
     @staticmethod
     def augment_record(router_entry, registration_record, id_key = 'mac_address'):

--- a/mktxp/flow/processor/output.py
+++ b/mktxp/flow/processor/output.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/flow/router_connection.py
+++ b/mktxp/flow/router_connection.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/flow/router_entries_handler.py
+++ b/mktxp/flow/router_entries_handler.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/flow/router_entry.py
+++ b/mktxp/flow/router_entry.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/mktxp/utils/utils.py
+++ b/mktxp/utils/utils.py
@@ -1,5 +1,5 @@
 # coding=utf8
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-## Copyright (c) 2020 Arseniy Kuznetsov
+## Copyright (c) 2024 Arseniy Kuznetsov
 ##
 ## This program is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License


### PR DESCRIPTION
This PR does 3 things:

1. It adds more SFP/SFP+ statistics
2. Allows configuration of whether unplugged/link-lost sfp modules are still logged
3. Adds a new print target for the above sfp/interface details

Currently tested and working on my CRS305