### PR TITLE
feat: includes public_address_ipv6

### DIFF
--- a/mktxp/collector/public_ip_collector.py
+++ b/mktxp/collector/public_ip_collector.py
@@ -23,14 +23,13 @@ class PublicIPAddressCollector(BaseCollector):
         if not router_entry.config_entry.public_ip:
             return
 
-        address_labels = ['public_address', 'dns_name']
+        address_labels = ['public_address', 'public_address_ipv6', 'dns_name']
         address_records = PublicIPAddressDatasource.metric_records(router_entry, metric_labels=address_labels)
 
         if address_records:
             for address_record in address_records:
                 if not 'dns_name' in address_record:
                     address_record['dns_name'] = 'ddns disabled'
-                    
+
             address_metrics = BaseCollector.info_collector('public_ip_address', 'Public IP address', address_records, address_labels)
             yield address_metrics
-


### PR DESCRIPTION
Mikrotik has thankfully added the public IPv6 prefix to the `/ip/cloud` output, though I’m not sure when this feature was introduced. There doesn’t seem to be a changelog that mentions it, but it is present in RouterOS 7.15.3 and later.