### PR TITLE
Only push image on main branch and releases

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
           platforms: |
             linux/amd64
             linux/arm64/v8


### PR DESCRIPTION
At the moment the tags for the docker image are only provided for releases, tags and branches. There are no tags extracted for PRs, this results in an empty tag list and the pipeline fails for PRs. This change enables the push only for the main branch and releases.

If you would like to push an image for every PR the following line has to be added.

```
tags: |
  ....
  # pull request event
  type=ref,event=pr
```