### PR TITLE
Add support to collect bfd metrics

### DIFF
--- a/mktxp/cli/config/config.py
+++ b/mktxp/cli/config/config.py
@@ -47,6 +47,7 @@ class CollectorKeys:
     QUEUE_SIMPLE_COLLECTOR = 'QueueSimpleCollector'
     KID_CONTROL_DEVICE_COLLECTOR = 'KidControlCollector'
     USER_COLLECTOR = 'UserCollector'
+    BFD_COLLECTOR = 'BFDCollector'
     BGP_COLLECTOR = 'BGPCollector'
     ROUTING_STATS_COLLECTOR = 'RoutingStatsCollector'
     EOIP_COLLECTOR = 'EOIPCollector'
@@ -111,6 +112,7 @@ class MKTXPConfigKeys:
 
     FE_USER_KEY = 'user'
     FE_QUEUE_KEY = 'queue'
+    FE_BFD_KEY = 'bfd'
     FE_BGP_KEY = 'bgp'
 
     FE_REMOTE_DHCP_ENTRY = 'remote_dhcp_entry'
@@ -169,7 +171,7 @@ class MKTXPConfigKeys:
 
 
     BOOLEAN_KEYS_NO = {ENABLED_KEY, SSL_KEY, NO_SSL_CERTIFICATE, FE_CHECK_FOR_UPDATES, FE_KID_CONTROL_DEVICE, FE_KID_CONTROL_DYNAMIC,
-                       SSL_CERTIFICATE_VERIFY, FE_IPV6_ROUTE_KEY, FE_IPV6_DHCP_POOL_KEY, FE_IPV6_FIREWALL_KEY, FE_IPV6_NEIGHBOR_KEY, FE_CONNECTION_STATS_KEY, FE_BGP_KEY,
+                       SSL_CERTIFICATE_VERIFY, FE_IPV6_ROUTE_KEY, FE_IPV6_DHCP_POOL_KEY, FE_IPV6_FIREWALL_KEY, FE_IPV6_NEIGHBOR_KEY, FE_CONNECTION_STATS_KEY, FE_BFD_KEY, FE_BGP_KEY,
                        FE_EOIP_KEY, FE_GRE_KEY, FE_IPIP_KEY, FE_IPSEC_KEY, FE_LTE_KEY, FE_SWITCH_PORT_KEY, FE_ROUTING_STATS_KEY, FE_CERTIFICATE_KEY, FE_DNS_KEY}
 
     # Feature keys enabled by default
@@ -202,7 +204,7 @@ class ConfigEntry:
                                                        MKTXPConfigKeys.FE_NETWATCH_KEY, MKTXPConfigKeys.MKTXP_USE_COMMENTS_OVER_NAMES, MKTXPConfigKeys.FE_PUBLIC_IP_KEY,
                                                        MKTXPConfigKeys.FE_ROUTE_KEY, MKTXPConfigKeys.FE_DHCP_POOL_KEY, MKTXPConfigKeys.FE_FIREWALL_KEY, MKTXPConfigKeys.FE_NEIGHBOR_KEY, MKTXPConfigKeys.FE_DNS_KEY,
                                                        MKTXPConfigKeys.FE_IPV6_ROUTE_KEY, MKTXPConfigKeys.FE_IPV6_DHCP_POOL_KEY, MKTXPConfigKeys.FE_IPV6_FIREWALL_KEY, MKTXPConfigKeys.FE_IPV6_NEIGHBOR_KEY,                                               
-                                                       MKTXPConfigKeys.FE_USER_KEY, MKTXPConfigKeys.FE_QUEUE_KEY, MKTXPConfigKeys.FE_REMOTE_DHCP_ENTRY, MKTXPConfigKeys.FE_REMOTE_CAPSMAN_ENTRY, MKTXPConfigKeys.FE_CHECK_FOR_UPDATES, MKTXPConfigKeys.FE_BGP_KEY,
+                                                       MKTXPConfigKeys.FE_USER_KEY, MKTXPConfigKeys.FE_QUEUE_KEY, MKTXPConfigKeys.FE_REMOTE_DHCP_ENTRY, MKTXPConfigKeys.FE_REMOTE_CAPSMAN_ENTRY, MKTXPConfigKeys.FE_CHECK_FOR_UPDATES, MKTXPConfigKeys.FE_BFD_KEY, MKTXPConfigKeys.FE_BGP_KEY,
                                                        MKTXPConfigKeys.FE_KID_CONTROL_DEVICE, MKTXPConfigKeys.FE_KID_CONTROL_DYNAMIC, MKTXPConfigKeys.FE_EOIP_KEY, MKTXPConfigKeys.FE_GRE_KEY, MKTXPConfigKeys.FE_IPIP_KEY, MKTXPConfigKeys.FE_LTE_KEY, MKTXPConfigKeys.FE_IPSEC_KEY, MKTXPConfigKeys.FE_SWITCH_PORT_KEY,
                                                        MKTXPConfigKeys.FE_ROUTING_STATS_KEY, MKTXPConfigKeys.FE_CERTIFICATE_KEY
                                                        ])

--- a/mktxp/cli/config/mktxp.conf
+++ b/mktxp/cli/config/mktxp.conf
@@ -72,6 +72,7 @@
     user = True                     # Active Users metrics
     queue = True                    # Queues metrics
 
+    bfd = False                     # BFD sessions metrics
     bgp = False                     # BGP sessions metrics
     routing_stats = False           # Routing process stats
     certificate = False             # Certificates metrics

--- a/mktxp/collector/bfd_collector.py
+++ b/mktxp/collector/bfd_collector.py
@@ -1,0 +1,108 @@
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+
+from mktxp.collector.base_collector import BaseCollector
+from mktxp.flow.processor.output import BaseOutputProcessor
+from mktxp.datasource.bfd_ds import BFDMetricsDataSource
+
+
+class BFDCollector(BaseCollector):
+    """
+    Bidirectional Forwarding Detection (BFD) collector
+    """
+    @staticmethod
+    def collect(router_entry):
+        if not router_entry.config_entry.bfd:
+            return
+
+        translation_table = {
+            "actual_tx_interval": lambda value: BaseOutputProcessor.parse_timedelta_milliseconds(value, ms_span=True) if value else "0",
+            "desired_tx_interval": lambda value: BaseOutputProcessor.parse_timedelta_milliseconds(value, ms_span=True) if value else "0",
+            "hold_time": lambda value: BaseOutputProcessor.parse_timedelta_milliseconds(value, ms_span=True) if value else "0",
+            "up": lambda value: "1" if value == "true" else "0",
+            "uptime": lambda value: BaseOutputProcessor.parse_timedelta_milliseconds(value) if value else "0",
+        }
+
+        default_labels = ["local_address", "remote_address"]
+        metric_records = BFDMetricsDataSource.metric_records(
+            router_entry,
+            translation_table=translation_table,
+        )
+
+        if not metric_records:
+            return
+
+        yield BaseCollector.gauge_collector(
+            "bfd_multiplier",
+            "The multiplier",
+            metric_records,
+            metric_key="multiplier",
+            metric_labels=default_labels
+        )
+        yield BaseCollector.gauge_collector(
+            "bfd_hold_time",
+            "The hold time in milliseconds",
+            metric_records,
+            metric_key="hold_time",
+            metric_labels=default_labels
+        )
+        yield BaseCollector.counter_collector(
+            "bfd_rx_packet",
+            "BFD control packets received",
+            metric_records,
+            metric_key="packets_rx",
+            metric_labels=default_labels,
+        )
+        yield BaseCollector.counter_collector(
+            "bfd_state_change",
+            "Number of time the state changed",
+            metric_records,
+            metric_key="state_changes",
+            metric_labels=default_labels,
+        )
+        yield BaseCollector.gauge_collector(
+            "bfd_tx_interval",
+            "The actual transmit interval",
+            metric_records,
+            metric_key="actual_tx_interval",
+            metric_labels=default_labels
+        )
+        yield BaseCollector.gauge_collector(
+            "bfd_tx_interval_desired",
+            "Desired transmit interval is the highes value from local tx interval and remote minimum rx interval",
+            metric_records,
+            metric_key="desired_tx_interval",
+            metric_labels=default_labels
+        )
+        yield BaseCollector.counter_collector(
+            "bfd_tx_packet",
+            "BFD control packets transmitted",
+            metric_records,
+            metric_key="packets_tx",
+            metric_labels=default_labels,
+        )
+        yield BaseCollector.gauge_collector(
+            "bfd_up",
+            "BFD is up",
+            metric_records,
+            metric_key="up",
+            metric_labels=default_labels
+        )
+        yield BaseCollector.gauge_collector(
+            "bfd_uptime",
+            "BFD uptime in milliseconds",
+            metric_records,
+            metric_key="uptime",
+            metric_labels=default_labels
+        )

--- a/mktxp/datasource/bfd_ds.py
+++ b/mktxp/datasource/bfd_ds.py
@@ -1,0 +1,35 @@
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+
+from mktxp.datasource.base_ds import BaseDSProcessor
+from mktxp.datasource.system_resource_ds import SystemResourceMetricsDataSource
+
+
+class BFDMetricsDataSource:
+    """Bidirectional Forwarding Detection (BFD) data provider"""
+    @staticmethod
+    def metric_records(router_entry, *, metric_labels = None, translation_table = None):
+        if metric_labels is None:
+            metric_labels = []
+        try:
+            bfd_records = router_entry.api_connection.router_api().get_resource("/routing/bfd/session").get()
+            return BaseDSProcessor.trimmed_records(
+                router_entry,
+                router_records=bfd_records,
+                metric_labels=metric_labels,
+                translation_table=translation_table
+            )
+        except Exception as exc:
+            print(f"Error getting BFD sessions info from router {router_entry.router_name}@{router_entry.config_entry.hostname}: {exc}")
+            return None

--- a/mktxp/flow/collector_registry.py
+++ b/mktxp/flow/collector_registry.py
@@ -38,6 +38,7 @@ from mktxp.collector.user_collector import UserCollector
 from mktxp.collector.queue_collector import QueueTreeCollector
 from mktxp.collector.queue_collector import QueueSimpleCollector
 from mktxp.collector.kid_control_device_collector import KidDeviceCollector
+from mktxp.collector.bfd_collector import BFDCollector
 from mktxp.collector.bgp_collector import BGPCollector
 from mktxp.collector.routing_stats_collector import RoutingStatsCollector
 from mktxp.collector.eoip_collector import EOIPCollector
@@ -86,6 +87,7 @@ class CollectorRegistry:
         self.register(CollectorKeys.QUEUE_SIMPLE_COLLECTOR, QueueSimpleCollector.collect)
 
         self.register(CollectorKeys.KID_CONTROL_DEVICE_COLLECTOR, KidDeviceCollector.collect)
+        self.register(CollectorKeys.BFD_COLLECTOR, BFDCollector.collect)
         self.register(CollectorKeys.BGP_COLLECTOR, BGPCollector.collect)
         self.register(CollectorKeys.EOIP_COLLECTOR, EOIPCollector.collect)
         self.register(CollectorKeys.GRE_COLLECTOR, GRECollector.collect)

--- a/mktxp/flow/router_entry.py
+++ b/mktxp/flow/router_entry.py
@@ -73,6 +73,7 @@ class RouterEntry:
                             CollectorKeys.QUEUE_SIMPLE_COLLECTOR: 0,                            
                             CollectorKeys.KID_CONTROL_DEVICE_COLLECTOR: 0,
                             CollectorKeys.USER_COLLECTOR: 0,
+                            CollectorKeys.BFD_COLLECTOR: 0,
                             CollectorKeys.BGP_COLLECTOR: 0,
                             CollectorKeys.ROUTING_STATS_COLLECTOR: 0,
                             CollectorKeys.EOIP_COLLECTOR: 0,


### PR DESCRIPTION
Add support to collect metrics for the Bidirectional Forwarding Detection (BFD). Tested with RouterOS 7.x