### PR TITLE
Fix scrape on metric `mktxp_certificate_expiration_timestamp_seconds` due to usage of `-`

### DIFF
--- a/mktxp/collector/certificate_collector.py
+++ b/mktxp/collector/certificate_collector.py
@@ -25,7 +25,7 @@ class CertificateCollector(BaseCollector):
         certificate_labels = ['name', 'digest_algorithm', 'key_type', 'country', 'state', 'locality', 'organization', 
                                 'common_name', 'key_size', 'subject_alt_name', 'days_valid', 'trusted', 'key_usage', 
                                 'ca', 'serial_number', 'key_usage', 'ca', 'serial_number', 'fingerprint', 'akid', 'skid', 
-                                'invalid_before', 'invalid_after', 'expires-after']
+                                'invalid_before', 'invalid_after', 'expires_after']
 
         translation_table = {
         }


### PR DESCRIPTION
It has been added in `v1.2.10` in metric `mktxp_certificate_expiration_timestamp_seconds`

![image](https://github.com/user-attachments/assets/c1c5ea7b-d3bb-4ff6-afd4-00182a36c675)
