### PR TITLE
Allow to use a custom CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The default configuration file comes with a sample configuration, making it easy
     use_ssl = False                 # enables connection via API-SSL servis
     no_ssl_certificate = False      # enables API_SSL connect without router SSL certificate
     ssl_certificate_verify = False  # turns SSL certificate verification on / off   
+    ssl_ca_file = ""                # path to the certificate authority file to validate against, leave empty to use system store
     plaintext_login = True          # for legacy RouterOS versions below 6.43 use False
 
     health = True                   # System Health metrics

--- a/mktxp/cli/config/config.py
+++ b/mktxp/cli/config/config.py
@@ -74,6 +74,7 @@ class MKTXPConfigKeys:
     SSL_KEY = 'use_ssl'
     NO_SSL_CERTIFICATE = 'no_ssl_certificate'
     SSL_CERTIFICATE_VERIFY = 'ssl_certificate_verify'
+    SSL_CA_FILE = 'ssl_ca_file'
     PLAINTEXT_LOGIN_KEY = 'plaintext_login'
 
     FE_HEALTH_KEY = 'health'
@@ -153,7 +154,9 @@ class MKTXPConfigKeys:
     # Default values    
     DEFAULT_HOST_KEY = 'localhost'
     DEFAULT_USER_KEY = 'user'
-    DEFAULT_PASSWORD_KEY = 'password'    
+    DEFAULT_PASSWORD_KEY = 'password'
+
+    DEFAULT_SSL_CA_FILE = ""
 
     DEFAULT_API_PORT = 8728
     DEFAULT_API_SSL_PORT = 8729
@@ -184,7 +187,7 @@ class MKTXPConfigKeys:
     SYSTEM_BOOLEAN_KEYS_YES = set()
     SYSTEM_BOOLEAN_KEYS_NO = {MKTXP_BANDWIDTH_KEY, MKTXP_VERBOSE_MODE, MKTXP_FETCH_IN_PARALLEL, MKTXP_COMPACT_CONFIG}
 
-    STR_KEYS = (HOST_KEY, USER_KEY, PASSWD_KEY, FE_REMOTE_DHCP_ENTRY, FE_REMOTE_CAPSMAN_ENTRY)
+    STR_KEYS = (HOST_KEY, USER_KEY, PASSWD_KEY, SSL_CA_FILE, FE_REMOTE_DHCP_ENTRY, FE_REMOTE_CAPSMAN_ENTRY)
     INT_KEYS =  ()
     MKTXP_INT_KEYS = (PORT_KEY, MKTXP_SOCKET_TIMEOUT, MKTXP_INITIAL_DELAY, MKTXP_MAX_DELAY,
                       MKTXP_INC_DIV, MKTXP_BANDWIDTH_TEST_INTERVAL, MKTXP_MIN_COLLECT_INTERVAL,
@@ -198,7 +201,7 @@ class MKTXPConfigKeys:
 class ConfigEntry:
     MKTXPConfigEntry = namedtuple('MKTXPConfigEntry', [MKTXPConfigKeys.ENABLED_KEY, MKTXPConfigKeys.HOST_KEY, MKTXPConfigKeys.PORT_KEY,
                                                        MKTXPConfigKeys.USER_KEY, MKTXPConfigKeys.PASSWD_KEY,
-                                                       MKTXPConfigKeys.SSL_KEY, MKTXPConfigKeys.NO_SSL_CERTIFICATE, MKTXPConfigKeys.SSL_CERTIFICATE_VERIFY, MKTXPConfigKeys.PLAINTEXT_LOGIN_KEY,
+                                                       MKTXPConfigKeys.SSL_KEY, MKTXPConfigKeys.NO_SSL_CERTIFICATE, MKTXPConfigKeys.SSL_CERTIFICATE_VERIFY, MKTXPConfigKeys.SSL_CA_FILE, MKTXPConfigKeys.PLAINTEXT_LOGIN_KEY,
                                                        MKTXPConfigKeys.FE_DHCP_KEY, MKTXPConfigKeys.FE_HEALTH_KEY, MKTXPConfigKeys.FE_PACKAGE_KEY, MKTXPConfigKeys.FE_DHCP_LEASE_KEY, MKTXPConfigKeys.FE_INTERFACE_KEY,
                                                        MKTXPConfigKeys.FE_MONITOR_KEY, MKTXPConfigKeys.FE_WIRELESS_KEY, MKTXPConfigKeys.FE_WIRELESS_CLIENTS_KEY,
                                                        MKTXPConfigKeys.FE_IP_CONNECTIONS_KEY, MKTXPConfigKeys.FE_CONNECTION_STATS_KEY, MKTXPConfigKeys.FE_CAPSMAN_KEY, MKTXPConfigKeys.FE_CAPSMAN_CLIENTS_KEY, MKTXPConfigKeys.FE_POE_KEY, 
@@ -459,7 +462,7 @@ class MKTXPConfigHandler:
                 new_keys.append(key) # read from disk next time
 
         for key in MKTXPConfigKeys.STR_KEYS:
-            if self.config[MKTXPConfigKeys.DEFAULT_ENTRY_KEY].get(key):
+            if self.config[MKTXPConfigKeys.DEFAULT_ENTRY_KEY].get(key) is not None:
                 default_config_entry_reader[key] = self.config[MKTXPConfigKeys.DEFAULT_ENTRY_KEY].get(key)
             else:
                 default_config_entry_reader[key] = self._default_value_for_key(key)
@@ -499,6 +502,7 @@ class MKTXPConfigHandler:
             MKTXPConfigKeys.USER_KEY: lambda _: MKTXPConfigKeys.DEFAULT_USER_KEY,
             MKTXPConfigKeys.PASSWD_KEY: lambda _: MKTXPConfigKeys.DEFAULT_PASSWORD_KEY,
             MKTXPConfigKeys.PORT_KEY: lambda _: MKTXPConfigKeys.DEFAULT_MKTXP_PORT,
+            MKTXPConfigKeys.SSL_CA_FILE: lambda _: MKTXPConfigKeys.DEFAULT_SSL_CA_FILE,
             MKTXPConfigKeys.FE_REMOTE_DHCP_ENTRY:  lambda _: MKTXPConfigKeys.DEFAULT_FE_REMOTE_DHCP_ENTRY,
             MKTXPConfigKeys.FE_REMOTE_CAPSMAN_ENTRY:  lambda _: MKTXPConfigKeys.DEFAULT_FE_REMOTE_CAPSMAN_ENTRY,
             MKTXPConfigKeys.MKTXP_SOCKET_TIMEOUT: lambda _: MKTXPConfigKeys.DEFAULT_MKTXP_SOCKET_TIMEOUT,

--- a/mktxp/cli/config/mktxp.conf
+++ b/mktxp/cli/config/mktxp.conf
@@ -28,6 +28,7 @@
     use_ssl = False                 # enables connection via API-SSL servis
     no_ssl_certificate = False      # enables API_SSL connect without router SSL certificate
     ssl_certificate_verify = False  # turns SSL certificate verification on / off   
+    ssl_ca_file = ""                # path to the certificate authority file to validate against, leave empty to use system store
     plaintext_login = True          # for legacy RouterOS versions below 6.43 use False
 
     health = True                   # System Health metrics

--- a/mktxp/flow/router_connection.py
+++ b/mktxp/flow/router_connection.py
@@ -53,9 +53,10 @@ class RouterAPIConnection:
         self.last_failure_timestamp = self.successive_failure_count = 0
         
         ctx = None
-        if self.config_entry.use_ssl and self.config_entry.no_ssl_certificate:
-            ctx = ssl.create_default_context()
-            ctx.set_ciphers('ADH:@SECLEVEL=0')       
+        if self.config_entry.use_ssl:
+            ctx = ssl.create_default_context(cafile=self.config_entry.ssl_ca_file if self.config_entry.ssl_ca_file else None)
+            if self.config_entry.no_ssl_certificate:
+                ctx.set_ciphers('ADH:@SECLEVEL=0')
 
         self.connection = RouterOsApiPool(
                 host = self.config_entry.hostname,


### PR DESCRIPTION
This PR allows to specify the path to a custom CA file instead of using the default system store. This way the custom CA does not have to be added to the system store in case you don't want every application to trust it.