### PR TITLE
Default to dual stack (also IPv6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ mktxp edit -i
 
 ```
 [MKTXP]
-    listen = '0.0.0.0:49090'         # Space separated list of socket addresses to listen to, both IPV4 and IPV6
+    listen = '*:49090'         # Space separated list of socket addresses to listen to, both IPV4 and IPV6
     socket_timeout = 2
     
     initial_delay_on_failure = 120
@@ -374,10 +374,10 @@ To keeps things within expected boundaries, the last two parameters allows for c
 
 
 ### mktxp endpoint listen addresses
-By default, mktxp runs it's HTTP metrics endpoint on any IPv4 address on port 49090. However, it is also able to listen on multiple socket addresses, both IPv4 and IPv6. 
+By default, mktxp runs it's HTTP metrics endpoint on any IPv4/IPv6 address on port 49090. However, it is also able to listen on multiple socket addresses, both IPv4 and IPv6. 
 You can configure this behaviour via the following [system option](https://github.com/akpw/mktxp/blob/main/README.md#mktxp-system-configuration), setting ```listen``` to a space-separated list of sockets to listen to, e.g.:
 ```
-listen = '0.0.0.0:49090 [::1]:49090'
+listen = '0.0.0.0:49090 [::]:49090'
 ```
 A wildcard for the hostname is supported as well, and binding to both IPv4/IPv6 as available.
 

--- a/deploy/kubernetes/secret.yaml
+++ b/deploy/kubernetes/secret.yaml
@@ -19,7 +19,7 @@ stringData:
 
 
         [MKTXP]
-            listen = '0.0.0.0:49090'         # Space separated list of socket addresses to listen to, both IPV4 and IPV6
+            listen = '*:49090'         # Space separated list of socket addresses to listen to, both IPV4 and IPV6
             socket_timeout = 5
             
             initial_delay_on_failure = 120

--- a/mktxp/cli/config/_mktxp.conf
+++ b/mktxp/cli/config/_mktxp.conf
@@ -12,7 +12,7 @@
 
 
 [MKTXP]
-    listen = '0.0.0.0:49090'         # Space separated list of socket addresses to listen to, both IPV4 and IPV6
+    listen = '*:49090'         # Space separated list of socket addresses to listen to, both IPV4 and IPV6
     socket_timeout = 5
     
     initial_delay_on_failure = 120

--- a/mktxp/cli/config/config.py
+++ b/mktxp/cli/config/config.py
@@ -378,7 +378,7 @@ class MKTXPConfigHandler:
         if self._config[entry_name].get(MKTXPConfigKeys.LISTEN_KEY):
             system_entry_reader[MKTXPConfigKeys.LISTEN_KEY] = self._config[entry_name].get(MKTXPConfigKeys.LISTEN_KEY)
         else:
-            system_entry_reader[MKTXPConfigKeys.LISTEN_KEY] = f'0.0.0.0:{system_entry_reader[MKTXPConfigKeys.PORT_KEY]}'
+            system_entry_reader[MKTXPConfigKeys.LISTEN_KEY] = f'*:{system_entry_reader[MKTXPConfigKeys.PORT_KEY]}'
             new_keys.append(MKTXPConfigKeys.LISTEN_KEY) # read from disk next time
 
         if new_keys:


### PR DESCRIPTION
Tested: If IPv6 is not present, will listen only on IPv4.

README: change IPv6 from link-local to any.