### PR TITLE
Fix some unclear ssl handling

### DIFF
--- a/mktxp/cli/config/config.py
+++ b/mktxp/cli/config/config.py
@@ -76,6 +76,7 @@ class MKTXPConfigKeys:
     SSL_KEY = 'use_ssl'
     NO_SSL_CERTIFICATE = 'no_ssl_certificate'
     SSL_CERTIFICATE_VERIFY = 'ssl_certificate_verify'
+    SSL_CHECK_HOSTNAME = 'ssl_check_hostname'
     SSL_CA_FILE = 'ssl_ca_file'
     PLAINTEXT_LOGIN_KEY = 'plaintext_login'
 
@@ -187,7 +188,7 @@ class MKTXPConfigKeys:
 
     # Feature keys enabled by default
     BOOLEAN_KEYS_YES = {PLAINTEXT_LOGIN_KEY, FE_DHCP_KEY, FE_HEALTH_KEY, FE_PACKAGE_KEY, FE_DHCP_LEASE_KEY, FE_IP_CONNECTIONS_KEY, FE_INTERFACE_KEY, 
-                        FE_ROUTE_KEY, FE_DHCP_POOL_KEY, FE_FIREWALL_KEY, FE_NEIGHBOR_KEY, FE_MONITOR_KEY, MKTXP_USE_COMMENTS_OVER_NAMES,
+                        FE_ROUTE_KEY, FE_DHCP_POOL_KEY, FE_FIREWALL_KEY, FE_NEIGHBOR_KEY, FE_MONITOR_KEY, SSL_CHECK_HOSTNAME, MKTXP_USE_COMMENTS_OVER_NAMES,
                         FE_WIRELESS_KEY, FE_WIRELESS_CLIENTS_KEY, FE_CAPSMAN_KEY, FE_CAPSMAN_CLIENTS_KEY, FE_POE_KEY,
                         FE_NETWATCH_KEY, FE_PUBLIC_IP_KEY, FE_USER_KEY, FE_QUEUE_KEY}
 
@@ -208,7 +209,7 @@ class MKTXPConfigKeys:
 class ConfigEntry:
     MKTXPConfigEntry = namedtuple('MKTXPConfigEntry', [MKTXPConfigKeys.ENABLED_KEY, MKTXPConfigKeys.HOST_KEY, MKTXPConfigKeys.PORT_KEY,
                                                        MKTXPConfigKeys.USER_KEY, MKTXPConfigKeys.PASSWD_KEY, MKTXPConfigKeys.CREDENTIALS_FILE_KEY,
-                                                       MKTXPConfigKeys.SSL_KEY, MKTXPConfigKeys.NO_SSL_CERTIFICATE, MKTXPConfigKeys.SSL_CERTIFICATE_VERIFY, MKTXPConfigKeys.SSL_CA_FILE, MKTXPConfigKeys.PLAINTEXT_LOGIN_KEY,
+                                                       MKTXPConfigKeys.SSL_KEY, MKTXPConfigKeys.NO_SSL_CERTIFICATE, MKTXPConfigKeys.SSL_CERTIFICATE_VERIFY, MKTXPConfigKeys.SSL_CHECK_HOSTNAME, MKTXPConfigKeys.SSL_CA_FILE, MKTXPConfigKeys.PLAINTEXT_LOGIN_KEY,
                                                        MKTXPConfigKeys.FE_DHCP_KEY, MKTXPConfigKeys.FE_HEALTH_KEY, MKTXPConfigKeys.FE_PACKAGE_KEY, MKTXPConfigKeys.FE_DHCP_LEASE_KEY, MKTXPConfigKeys.FE_INTERFACE_KEY,
                                                        MKTXPConfigKeys.FE_MONITOR_KEY, MKTXPConfigKeys.FE_WIRELESS_KEY, MKTXPConfigKeys.FE_WIRELESS_CLIENTS_KEY,
                                                        MKTXPConfigKeys.FE_IP_CONNECTIONS_KEY, MKTXPConfigKeys.FE_CONNECTION_STATS_KEY, MKTXPConfigKeys.FE_CAPSMAN_KEY, MKTXPConfigKeys.FE_CAPSMAN_CLIENTS_KEY, MKTXPConfigKeys.FE_POE_KEY, 

--- a/mktxp/cli/config/mktxp.conf
+++ b/mktxp/cli/config/mktxp.conf
@@ -28,7 +28,8 @@
     
     use_ssl = False                 # enables connection via API-SSL servis
     no_ssl_certificate = False      # enables API_SSL connect without router SSL certificate
-    ssl_certificate_verify = False  # turns SSL certificate verification on / off   
+    ssl_certificate_verify = False  # turns SSL certificate verification on / off
+    ssl_check_hostname = True       # check if the hostname matches the peer cert’s hostname
     ssl_ca_file = ""                # path to the certificate authority file to validate against, leave empty to use system store
     plaintext_login = True          # for legacy RouterOS versions below 6.43 use False
 


### PR DESCRIPTION
- no_ssl_certificate = true
  - The changes in #236 broke the expected behaviour
  - This allows to connect without certificate using an anonymous Diffie-Hellman cipher
- ssl_check_hostname
  - Enable/disable the check of the peer hostname in the certificate

Please check if everything is working as expected.

If a ca file is provided with ```create_default_context()``` it should already call ```load_verify_locations()```

See: https://github.com/python/cpython/blob/5a7f5ea631aa658f92d651a32d1d064fe9818156/Lib/ssl.py#L716-L717

In #236 the possibility to connect without an certificate has been removed by removing the following line.

```
ctx.set_ciphers('ADH:@SECLEVEL=0') 
```

This PR restores the expected behaviour for connections without certificate. The other changes are mostly adapted from https://github.com/socialwifi/RouterOS-api/blob/8988caf058945b79b93318c1300eac18d2877192/routeros_api/api_socket.py#L26-L33

Please feel free to comment or ask questions.