### PR TITLE
change channel rss mapping for testing channel

### DIFF
--- a/mktxp/utils/utils.py
+++ b/mktxp/utils/utils.py
@@ -272,7 +272,7 @@ CHANNEL_RSS_FEED_MAPPING = {
     'development': 'https://mikrotik.com/development.rss',
     'long-term': 'https://mikrotik.com/bugfix.rss',
     'stable': 'https://mikrotik.com/current.rss',
-    'testing': 'https://mikrotik.com/candidate.rss',
+    'testing': 'https://download.mikrotik.com/routeros/latest-testing.rss',
 }
 
 


### PR DESCRIPTION
Hi,
I face this problem `update feed returned: HTTP Error 404: Not Found` - `Fetching available ROS releases from https://mikrotik.com/candidate.rss`. When I look deeper, I see that they change the RSS address. So I created this pull request. 