### PR TITLE
feat: 改进配置文件管理和添加 entry 命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 
 ## Description
-MKTXP is a Prometheus Exporter for Mikrotik RouterOS devices.\
+RouterOS_Exporter is a Prometheus Exporter for Mikrotik RouterOS devices.\
 It gathers and exports a rich set of metrics across multiple routers, all easily configurable via built-in CLI interface. 
 
-While simple to use, MKTXP supports [advanced features](https://github.com/akpw/mktxp#advanced-features) such as automatic IP address resolution with both local & remote DHCP servers, concurrent exports across multiple router devices, configurable data processing & transformations, injectable custom labels for easy device grouping, optional bandwidth testing, etc.
+While simple to use, RouterOS_Exporter supports [advanced features](https://github.com/online2311/RouterOS_Exporter#advanced-features) such as automatic IP address resolution with both local & remote DHCP servers, concurrent exports across multiple router devices, configurable data processing & transformations, injectable custom labels for easy device grouping, optional bandwidth testing, etc.
 
-Apart from exporting to Prometheus, MKTXP can print selected metrics directly on the command line (see examples below). 
+Apart from exporting to Prometheus, RouterOS_Exporter can print selected metrics directly on the command line (see examples below). 
 
-For effortless visualization of the RouterOS metrics exported to Prometheus, MKTXP comes with a dedicated [Grafana dashboard](https://grafana.com/grafana/dashboards/13679):
+For effortless visualization of the RouterOS metrics exported to Prometheus, RouterOS_Exporter comes with a dedicated [Grafana dashboard](https://grafana.com/grafana/dashboards/13679):
 
 <img width="32%" alt="1" src="https://user-images.githubusercontent.com/5028474/217029083-3c2f561e-853f-45a7-b9f1-d818a830daf5.png"> <img width="32%" alt="2" src="https://user-images.githubusercontent.com/5028474/217029092-2b86b41b-1f89-4383-ac48-16652e820f7e.png"> <img width="32%" alt="3" src="https://user-images.githubusercontent.com/5028474/217029096-dbf6b46c-3ed7-4c76-a57b-8cebfb3b671c.png">
 
@@ -33,22 +33,22 @@ For effortless visualization of the RouterOS metrics exported to Prometheus, MKT
 
 
 ## Install:
-There are multiple ways to install this project, from a standalone app to a [fully dockerized monitoring stack](https://github.com/akpw/mktxp-stack). The supported options include:
-- [MKTXP Stack](https://github.com/akpw/mktxp-stack): a mktxp companion project, that provides ready-to-go MKTXP monitoring stack along with added Mikrotik centralized log processing:
+There are multiple ways to install this project, from a standalone app to a [fully dockerized monitoring stack](https://github.com/online2311/RouterOS_Exporter-stack). The supported options include:
+- [RouterOS_Exporter Stack](https://github.com/online2311/RouterOS_Exporter-stack): a RouterOS_Exporter companion project, that provides ready-to-go RouterOS_Exporter monitoring stack along with added Mikrotik centralized log processing:
 
   <img width="48%" alt="loki" src="https://user-images.githubusercontent.com/5028474/210771516-06a3e6ab-8eab-458c-9f38-5d44f95d23d4.png">
 
-- from [Docker image](https://github.com/akpw/mktxp/pkgs/container/mktxp) : `❯ docker pull ghcr.io/akpw/mktxp:latest`
+- from [Docker image](https://github.com/online2311/RouterOS_Exporter/pkgs/container/RouterOS_Exporter) : `❯ docker pull ghcr.io/akpw/RouterOS_Exporter:latest`
 
-- from [PyPI](https://pypi.org/project/mktxp/): `❯ pip install mktxp`
+- from [PyPI](https://pypi.org/project/RouterOS_Exporter/): `❯ pip install RouterOS_Exporter`
 
-- latest from source repository: `❯ pip install git+https://github.com/akpw/mktxp`
+- latest from source repository: `❯ pip install git+https://github.com/online2311/RouterOS_Exporter`
 
 - with the [sample Kubernetes deployment](deploy/kubernetes/deployment.yaml)
 
 
 ## Getting started
-To get started with MKTXP, you need to edit its main configuration file. This essentially involves filling in your Mikrotik devices IP addresses & authentication info, optionally modifying various settings to specific needs. 
+To get started with RouterOS_Exporter, you need to edit its main configuration file. This essentially involves filling in your Mikrotik devices IP addresses & authentication info, optionally modifying various settings to specific needs. 
 
 The default configuration file comes with a sample configuration, making it easy to copy / edit parameters for your RouterOS devices as needed:
 ```
@@ -135,63 +135,67 @@ The default configuration file comes with a sample configuration, making it easy
 
     container = False               # Containers metrics
     
-    remote_dhcp_entry = None        # An MKTXP entry to provide for remote DHCP info / resolution
-    remote_capsman_entry = None     # An MKTXP entry to provide for remote capsman info 
+    remote_dhcp_entry = None        # An RouterOS_Exporter entry to provide for remote DHCP info / resolution
+    remote_capsman_entry = None     # An RouterOS_Exporter entry to provide for remote capsman info 
 
     use_comments_over_names = True  # when available, forces using comments over the interfaces names
     check_for_updates = False       # check for available ROS updates
 ```
 
-Most options are easy to understand at first glance, and some are described in more details [later](https://github.com/akpw/mktxp#advanced-features).
+Most options are easy to understand at first glance, and some are described in more details [later](https://github.com/online2311/RouterOS_Exporter#advanced-features).
 
-<sup>💡</sup> To automatically migrate from the older `mktxp.conf` format in the existing installs, just set `compact_default_conf_values = True` in [the mktxp system config](https://github.com/akpw/mktxp#mktxp-system-configuration)
+<sup>💡</sup> To automatically migrate from the older `routeros_exporter.conf` format in the existing installs, just set `compact_default_conf_values = True` in [the RouterOS_Exporter system config](https://github.com/online2311/RouterOS_Exporter#RouterOS_Exporter-system-configuration)
 
 #### Local install
-If you have a local MKTXP installation, you can edit the configuration file with your default system editor directly from mktxp:
+If you have a local routeros_exporter installation, you can edit the configuration file with your default system editor directly from routeros_exporter:
 ```bash
-❯ mktxp edit
+❯ routeros_exporter edit
 ```
 In case you prefer a different editor, run the ```edit``` command with its optional `-ed` parameter:
 ```
-❯ mktxp edit -ed nano
+❯ routeros_exporter edit -ed nano
 ```
 Obviously, you can do the same via just opening the config file directly:
 ```
-❯ nano ~/mktxp/mktxp.conf
+❯ nano ~/routeros_exporter/routeros_exporter.conf
 
 ```
 
 #### Docker image install
-For Docker instances, one way is to use a configured `mktxp.conf` file from a local installation. Alternatively you can create a standalone one in a dedicated folder:
+For Docker instances, the configuration files are located in `/app/` inside the container:
+- `/app/device.conf` - Router device configurations
+- `/app/exporter.conf` - System runtime configurations
+
+You can create standalone configuration files in a dedicated folder:
 ```
-mkdir mktxp
-nano mktxp/mktxp.conf # copy&edit sample entry(ies) from above
+mkdir -p app
+nano app/device.conf # copy&edit sample entry(ies) from above
 ```
 Now you can mount this folder and run your docker instance with:
 ```
-docker run -v "$(pwd)/mktxp:/home/mktxp/mktxp/" -p 49090:49090 -it --rm ghcr.io/akpw/mktxp:latest
+docker run -v "$(pwd)/app:/app" -p 49090:49090 -it --rm ghcr.io/akpw/routeros_exporter:latest
 ```
 
-#### MKTXP stack install
-[MKTXP Stack Getting Started](https://github.com/akpw/mktxp-stack#install--getting-started) provides similar instructions around editing the mktxp.conf file and, if needed, adding a dedicated API user to your Mikrotik RouterOS devices as mentioned below.
+#### RouterOS_Exporter stack install
+[RouterOS_Exporter Stack Getting Started](https://github.com/online2311/RouterOS_Exporter-stack#install--getting-started) provides similar instructions around editing the routeros_exporter.conf file and, if needed, adding a dedicated API user to your Mikrotik RouterOS devices as mentioned below.
 
-<sup>💡</sup> *In the case of usage within a [Docker Swarm](https://docs.docker.com/engine/swarm/), please do make sure to have all settings explicitly set in both the `mktxp.conf` and `_mktxp.conf` files.  Not doing this may cause [issues](https://github.com/akpw/mktxp/issues/55#issuecomment-1346693843) regarding a `read-only` filesystem.*
+<sup>💡</sup> *In the case of usage within a [Docker Swarm](https://docs.docker.com/engine/swarm/), please do make sure to have all settings explicitly set in both the `routeros_exporter.conf` and `_routeros_exporter.conf` files.  Not doing this may cause [issues](https://github.com/online2311/RouterOS_Exporter/issues/55#issuecomment-1346693843) regarding a `read-only` filesystem.*
 
 ## Mikrotik Device Config
 For the purpose of RouterOS device monitoring, it's best to create a dedicated user with minimal required permissions. \
-MKTXP only needs ```API``` and ```Read```<sup>💡</sup>, so at that point you can go to your router's terminal and type:
+RouterOS_Exporter only needs ```API``` and ```Read```<sup>💡</sup>, so at that point you can go to your router's terminal and type:
 ```
-/user group add name=mktxp_group policy=api,read
-/user add name=mktxp_user group=mktxp_group password=mktxp_user_password
+/user group add name=routeros_exporter_group policy=api,read
+/user add name=routeros_exporter_user group=routeros_exporter_group password=routeros_exporter_user_password
 ```
 
-<sup>💡</sup> *For the LTE metrics on RouterOS v6, the mktxp user will also need the `test` permission policy.*
+<sup>💡</sup> *For the LTE metrics on RouterOS v6, the RouterOS_Exporter user will also need the `test` permission policy.*
 
 ## A check on reality
-Now let's put some Mikrotik device address / user credentials in the above MKTXP configuration file, and at that point we should already be able to check out on our progress so far. Since MKTXP can output selected metrics directly on the command line with the ````mktxp print```` command, it's easy to do it even without Prometheus or Grafana. \
+Now let's put some Mikrotik device address / user credentials in the above RouterOS_Exporter configuration file, and at that point we should already be able to check out on our progress so far. Since RouterOS_Exporter can output selected metrics directly on the command line with the ````routeros_exporter print```` command, it's easy to do it even without Prometheus or Grafana. \
 For example, let's go take a look at some of my smart home CAPsMAN clients:
 ```
- ❯ mktxp print -en MKT-GT -cc
+ ❯ routeros_exporter print -en MKT-GT -cc
 Connecting to router MKT-GT@10.**.*.**
 2021-01-24 12:04:29 Connection to router MKT-GT@10.**.*.** has been established
 
@@ -223,7 +227,7 @@ But let's get back on track and proceed with the business of exporting RouterOS 
 
 
 ## Exporting to Prometheus
-For getting your routers' metrics into an existing Prometheus installation, we basically just need to connect MKTXP to it. \
+For getting your routers' metrics into an existing Prometheus installation, we basically just need to connect RouterOS_Exporter to it. \
 Let's do just that via editing the Prometheus config file: 
 ```
 ❯ nano /etc/prometheus/prometheus.yml
@@ -232,15 +236,15 @@ Let's do just that via editing the Prometheus config file:
 and simply add:
 
 ```
-  - job_name: 'mktxp'
+  - job_name: 'RouterOS_Exporter'
     static_configs:
-      - targets: ['mktxp_machine_IP:49090']
+      - targets: ['routeros_exporter_machine_IP:49090']
 
 ```
 
-At that point, we should be all ready for running the main `mktxp export` command that will be gathering router(s) metrics as configured above and serving them to Prometheus via a http server on the default port 49090. \
+At that point, we should be all ready for running the main `routeros_exporter export` command that will be gathering router(s) metrics as configured above and serving them to Prometheus via a http server on the default port 49090. \
 ````
-❯ mktxp export
+❯ routeros_exporter export
 Connecting to router MKT-GT@10.**.*.**
 2021-01-24 14:16:22 Connection to router MKT-GT@10.**.*.** has been established
 Connecting to router MKT-LR@10.**.*.**
@@ -248,15 +252,15 @@ Connecting to router MKT-LR@10.**.*.**
 2021-01-24 14:16:23 Running HTTP metrics server on port 49090
 ````
 
-## MKTXP system configuration
-In case you need more control on how MKTXP is run, it can be done via editing the `_mktxp.conf` file. This allows things like changing the port <sup>💡</sup> and other impl-related parameters, enable parallel router fetching and configurable scrapes timeouts, etc. 
-As before, for local installation the editing can be done directly from mktxp:
+## RouterOS_Exporter system configuration
+In case you need more control on how RouterOS_Exporter is run, it can be done via editing the `exporter.conf` file. This allows things like changing the port <sup>💡</sup> and other impl-related parameters, enable parallel router fetching and configurable scrapes timeouts, etc.
+As before, for local installation the editing can be done directly from RouterOS_Exporter:
 ```
-mktxp edit -i
+routeros_exporter edit -i
 ```
 
 ```
-[MKTXP]
+[RouterOS_Exporter]
     listen = '0.0.0.0:49090'         # Space separated list of socket addresses to listen to, both IPV4 and IPV6
     socket_timeout = 2
     
@@ -277,58 +281,80 @@ mktxp edit -i
 
     persistent_router_connection_pool = True  # Use a persistent router connections pool between scrapes
     persistent_dhcp_cache = True              # Persist DHCP cache between metric collections
-    compact_default_conf_values = False       # Compact mktxp.conf, so only specific values are kept on the individual routers' level    
+    compact_default_conf_values = False       # Compact RouterOS_Exporter.conf, so only specific values are kept on the individual routers' level    
     prometheus_headers_deduplication = False  # Deduplicate Prometheus HELP / TYPE headers in the metrics output 
 ```    
-<sup>💡</sup> *When changing the default mktxp port for [docker image installs](https://github.com/akpw/mktxp#docker-image-install), you'll need to adjust the `docker run ... -p 49090:49090 ...` command to reflect the new port*
+<sup>💡</sup> *When changing the default RouterOS_Exporter port for [docker image installs](https://github.com/online2311/RouterOS_Exporter#docker-image-install), you'll need to adjust the `docker run ... -p 49090:49090 ...` command to reflect the new port*
 
 ## Grafana dashboard
 Now with your RouterOS metrics being exported to Prometheus, it's easy to visualize them with this [Grafana dashboard](https://grafana.com/grafana/dashboards/13679)
 
 
 ## Description of CLI Commands
-### mktxp commands
-       . MKTXP commands:
-        .. info     Shows base MKTXP info
-        .. edit     Open MKTXP configuration file in your editor of choice        
+### routeros_exporter commands
+       . routeros_exporter commands:
+        .. info     Shows base routeros_exporter info
+        .. edit     Open routeros_exporter configuration file in your editor of choice
+        .. entry    Creates a new router configuration entry
         .. print    Displays selected metrics on the command line
         .. export   Starts collecting metrics for all enabled RouterOS configuration entries
-        .. show     Shows MKTXP configuration entries on the command line
+        .. show     Shows routeros_exporter configuration entries on the command line
 
 ````
-❯ mktxp -h
-usage: MKTXP [-h] [--cfg-dir CFG_DIR] {info, edit, export, print, show, } ...
+❯ routeros_exporter -h
+usage: routeros_exporter [-h] [--cfg-dir CFG_DIR] {info, edit, entry, export, print, show} ...
 
 Prometheus Exporter for Mikrotik RouterOS
 
 optional arguments:
   -h, --help            show this help message and exit
-  --cfg-dir CFG_DIR     MKTXP config files directory (optional)
+  --cfg-dir CFG_DIR     routeros_exporter config files directory (optional)
 ````
 To learn more about individual commands, just run it with ```-h```:
-For example, to learn everything about ````mktxp show````:
+For example, to learn everything about ````routeros_exporter show````:
 ````
-❯ mktxp show -h
-usage: MKTXP show [-h]
+❯ routeros_exporter show -h
+usage: routeros_exporter show [-h]
                   [-en ['Sample-Router']]
                   [-cfg]
-Displays MKTXP config router entries
+Displays routeros_exporter config router entries
 optional arguments:
   -h, --help            show this help message and exit
   -en, --entry-name ['Sample-Router']
                         Config entry name
-  -cfg, --config        Shows MKTXP config files paths
-````  
+  -cfg, --config        Shows routeros_exporter config files paths
+````
+
+### Creating a new router entry
+You can quickly create a new router configuration entry using the `entry` command:
+````
+❯ routeros_exporter entry -n MyRouter -hn 192.168.88.1 -u admin -pw mypassword
+成功创建配置条目 [MyRouter]
+配置文件位置: /app/device.conf  # Docker 环境
+# 或 ~/routeros_exporter/routeros_exporter.conf  # 本地安装
+
+使用以下命令编辑完整配置:
+  routeros_exporter edit
+````
+This creates a new `[MyRouter]` section in your configuration file with the specified hostname, username, and password. You can then use `routeros_exporter edit` to customize additional settings like SSL, metrics collection options, custom labels, etc.
+
+**Configuration Files:**
+- **Docker/Linux**:
+  - Device config: `/app/device.conf`
+  - System config: `/app/exporter.conf`
+- **macOS/FreeBSD**:
+  - Device config: `~/routeros_exporter/routeros_exporter.conf`
+  - System config: `~/routeros_exporter/exporter.conf`
 
 ## Advanced features
-While most of the [mktxp options](https://github.com/akpw/mktxp#getting-started) are self explanatory, some might require a bit of a context.
+While most of the [RouterOS_Exporter options](https://github.com/online2311/RouterOS_Exporter#getting-started) are self explanatory, some might require a bit of a context.
 
 ### Remote DHCP resolution
-When gathering various IP address-related metrics, MKTXP automatically resolves IP addresses whenever DHCP info is available. In many cases however, the exported devices do not have this information locally and instead rely on central DHCP servers. To improve readability / usefulness of the exported metrics, MKTXP supports remote DHCP server calls via the following option:
+When gathering various IP address-related metrics, RouterOS_Exporter automatically resolves IP addresses whenever DHCP info is available. In many cases however, the exported devices do not have this information locally and instead rely on central DHCP servers. To improve readability / usefulness of the exported metrics, RouterOS_Exporter supports remote DHCP server calls via the following option:
 ```
-remote_dhcp_entry = None        # An MKTXP entry to provide for remote DHCP info / resolution
+remote_dhcp_entry = None        # An RouterOS_Exporter entry to provide for remote DHCP info / resolution
 ```
-`MKTXP entry` in this context can be any other mktxp.conf entry, and for the sole purpose of providing DHCP info it does not even need to be enabled.  An example:
+`routeros_exporter entry` in this context can be any other RouterOS_Exporter.conf entry, and for the sole purpose of providing DHCP info it does not even need to be enabled.  An example:
 ```
 [RouterA]
     ...  # RouterA settings as normal
@@ -338,11 +364,11 @@ remote_dhcp_entry = None        # An MKTXP entry to provide for remote DHCP info
 ```
 
 ### Remote CAPsMAN info
-Similar to remote DHCP resolution, mktxp allows collecting CAPsMAN-related metrics via the following option: 
+Similar to remote DHCP resolution, RouterOS_Exporter allows collecting CAPsMAN-related metrics via the following option: 
 ```
-    remote_capsman_entry = None     # An MKTXP entry to provide for remote capsman info
+    remote_capsman_entry = None     # An RouterOS_Exporter entry to provide for remote capsman info
 ```
-`MKTXP entry` in this context can be any other mktxp.conf entry, and for the sole purpose of collecting CAPsMAN-related metrics it does not even need to be enabled.  An example:
+`routeros_exporter entry` in this context can be any other routeros_exporter.conf entry, and for the sole purpose of collecting CAPsMAN-related metrics it does not even need to be enabled.  An example:
 ```
 [RouterA]
     ...  # RouterA settings as normal
@@ -352,7 +378,7 @@ Similar to remote DHCP resolution, mktxp allows collecting CAPsMAN-related metri
 ```
 
 ### Kid Control device monitoring
-MKTXP Kid Control metrics help track network activity and bandwidth usage for all connected devices on a RouterOS network. This makes it easy to identify high-traffic devices and monitor network usage patterns in real-time.
+RouterOS_Exporter Kid Control metrics help track network activity and bandwidth usage for all connected devices on a RouterOS network. This makes it easy to identify high-traffic devices and monitor network usage patterns in real-time.
 
 The Kid Control functionality offers two modes of operation:
 ```
@@ -362,7 +388,7 @@ kid_control_dynamic = False     # Allow Kid Control metrics for all connected de
 
 When set up on the router, is is possible to view Kid Control device metrics directly from the command line:
 ```
-❯ mktxp print -en MKT-GT -kc
+❯ routeros_exporter print -en MKT-GT -kc
 MKT-GT@10.70.0.1: OK to connect
 Connecting to router MKT-GT@10.70.0.1
 2025-09-24 12:08:42 Connection to router MKT-GT@10.70.0.1 has been established
@@ -387,10 +413,10 @@ Total Kid Control devices: 8
 The devices are automatically sorted by total bandwidth usage (upload + download rates), making it easy to identify high-traffic devices at a glance.
 
 ### Address List device monitoring
-Similarly to the above, MKTXP IPv4 / IPv6 firewall address lists can be inspected directly from the command line. The feature supports multiple address lists and automatically detects which IP versions contain which entries.
+Similarly to the above, RouterOS_Exporter IPv4 / IPv6 firewall address lists can be inspected directly from the command line. The feature supports multiple address lists and automatically detects which IP versions contain which entries.
 
 ```
-❯ mktxp print -en MKT-GT -al "blocklist, allowlist"
+❯ routeros_exporter print -en MKT-GT -al "blocklist, allowlist"
 MKT-GT@10.70.0.1: OK to connect
 Connecting to router MKT-GT@10.70.0.1
 2025-09-25 12:15:30 Connection to router MKT-GT@10.70.0.1 has been established
@@ -418,7 +444,7 @@ Unique lists: 1
 The command automatically queries both IPv4 and IPv6 address lists, displaying separate tables when entries exist in both IP versions. Missing lists are reported as warnings, and entries are sorted by list name and then by address for easy scanning.
 
 ### Connections stats
-With many connected devices everywhere, one can often only guess where do they go to and what they actually do with all the information from your network environment. MKTXP let's you easily track those with a single option, with results available both from [mktxp dashboard](https://grafana.com/grafana/dashboards/13679-mikrotik-mktxp-exporter/) and the command line:
+With many connected devices everywhere, one can often only guess where do they go to and what they actually do with all the information from your network environment. RouterOS_Exporter let's you easily track those with a single option, with results available both from [RouterOS_Exporter dashboard](https://grafana.com/grafana/dashboards/13679-mikrotik-RouterOS_Exporter-exporter/) and the command line:
 
 ```
 connection_stats = False        # Open IP connections metrics 
@@ -431,7 +457,7 @@ Hey, what is this Temp&Humidity sensor has to do with a bunch of open network co
 Let's go check on that in the dashboard, or just get the info right from the command line:
 
 ```
-❯ mktxp print -en MKT-GT -cn
+❯ routeros_exporter print -en MKT-GT -cn
 +-------------------+--------------+------------------+-----------------------------------------------------------------------+
 |     dhcp_name     | src_address  | connection_count |                             dst_addresses                             |
 +===================+==============+==================+=======================================================================+
@@ -442,7 +468,7 @@ Let's go check on that in the dashboard, or just get the info right from the com
 
 
 ### Parallel routers fetch
-Concurrent exports across multiple devices can considerably speed up things for slow network connections. This feature can be turned on and configured with the following [system options](https://github.com/akpw/mktxp/blob/main/README.md#mktxp-system-configuration):
+Concurrent exports across multiple devices can considerably speed up things for slow network connections. This feature can be turned on and configured with the following [system options](https://github.com/online2311/RouterOS_Exporter/blob/main/README.md#RouterOS_Exporter-system-configuration):
 ```
 fetch_routers_in_parallel = False   # Set to True if you want to fetch multiple routers parallel
 max_worker_threads = 5              # Max number of worker threads that can fetch routers (parallel fetch only)
@@ -455,21 +481,21 @@ To keeps things within expected boundaries, the last two parameters allows for c
 ### Injectable router-level custom labels
 You can add custom labels to your devices using the `custom_labels` option. These labels are attached to all the metrics for a specific device, allowing e.g. easy router grouping for detailed overview dashboards in Grafana. You can define default labels in the `[default]` section and override or extend them in the router-specific sections.
 
-### mktxp endpoint listen addresses
-By default, mktxp runs it's HTTP metrics endpoint on any IPv4 address on port 49090. However, it is also able to listen on multiple socket addresses, both IPv4 and IPv6. 
-You can configure this behaviour via the following [system option](https://github.com/akpw/mktxp/blob/main/README.md#mktxp-system-configuration), setting ```listen``` to a space-separated list of sockets to listen to, e.g.:
+### RouterOS_Exporter endpoint listen addresses
+By default, RouterOS_Exporter runs it's HTTP metrics endpoint on any IPv4 address on port 49090. However, it is also able to listen on multiple socket addresses, both IPv4 and IPv6. 
+You can configure this behaviour via the following [system option](https://github.com/online2311/RouterOS_Exporter/blob/main/README.md#RouterOS_Exporter-system-configuration), setting ```listen``` to a space-separated list of sockets to listen to, e.g.:
 ```
 listen = '0.0.0.0:49090 [::1]:49090'
 ```
 A wildcard for the hostname is supported as well, and binding to both IPv4/IPv6 as available.
 
-## Setting up MKTXP to run as a Linux Service
-If you've installed MKTXP on a Linux system, you can run it with system boot via adding a service. \
+## Setting up RouterOS_Exporter to run as a Linux Service
+If you've installed RouterOS_Exporter on a Linux system, you can run it with system boot via adding a service. \
 Let's start with:
 
 
 ```
-❯ nano /etc/systemd/system/mktxp.service
+❯ nano /etc/systemd/system/routeros_exporter.service
 
 ```
 
@@ -477,11 +503,11 @@ Now copy and paste the following:
 
 ```
 [Unit]
-Description=MKTXP Exporter
+Description=RouterOS_Exporter Exporter
 
 [Service]
-User=user # the user under which mktxp was installed
-ExecStart=mktxp export # if mktxp is not at your $PATH, you might need to provide a full path
+User=user # the user under which RouterOS_Exporter was installed
+ExecStart=routeros_exporter export # if RouterOS_Exporter is not at your $PATH, you might need to provide a full path
 
 [Install]
 WantedBy=default.target
@@ -491,24 +517,24 @@ WantedBy=default.target
 Let's save and then start the service as well as check on its' status:
 ```
 ❯ sudo systemctl daemon-reload
-❯ sudo systemctl start mktxp
-❯ sudo systemctl enable mktxp
+❯ sudo systemctl start routeros_exporter
+❯ sudo systemctl enable routeros_exporter
 
-❯ systemctl status mktxp
-● mktxp.service - MKTXP Mikrotik Exporter to Prometheus
-     Loaded: loaded (/etc/systemd/system/mktxp.service; disabled; vendor preset: enabled)
+❯ systemctl status RouterOS_Exporter
+● routeros_exporter.service - RouterOS_Exporter Mikrotik Exporter to Prometheus
+     Loaded: loaded (/etc/systemd/system/routeros_exporter.service; disabled; vendor preset: enabled)
      Active: active (running) since Sun 2021-01-24 09:16:44 CET; 2h 44min ago
      ...
 ```
 
 
-## Setting up MKTXP to run as a FreeBSD Service
-If you've installed MKTXP on a FreeBSD system, you can run it with system boot via adding a service. \
+## Setting up RouterOS_Exporter to run as a FreeBSD Service
+If you've installed RouterOS_Exporter on a FreeBSD system, you can run it with system boot via adding a service. \
 Let's start with:
 
 
 ```
-❯ nano /usr/local/etc/rc.d/mktxp
+❯ nano /usr/local/etc/rc.d/routeros_exporter
 ```
 
 Now copy and paste the following:
@@ -516,33 +542,33 @@ Now copy and paste the following:
 ```
 #!/bin/sh
 
-# PROVIDE: mktxp
+# PROVIDE: RouterOS_Exporter
 # REQUIRE: DAEMON NETWORKING
 # BEFORE: LOGIN
 # KEYWORD: shutdown
 
-# Add the following lines to /etc/rc.conf to enable mktxp:
-# mktxp_enable="YES"
+# Add the following lines to /etc/rc.conf to enable RouterOS_Exporter:
+# routeros_exporter_enable="YES"
 #
-# mktxp_enable (bool):    Set to YES to enable mktxp
+# routeros_exporter_enable (bool):    Set to YES to enable RouterOS_Exporter
 #                Default: NO
-# mktxp_user (str):       mktxp daemon user
+# routeros_exporter_user (str):       RouterOS_Exporter daemon user
 #                Default: root
 
 . /etc/rc.subr
 
-name=mktxp
-rcvar=mktxp_enable 
+name=routeros_exporter
+rcvar=routeros_exporter_enable 
 
-: ${mktxp_enable:="NO"}
-: ${mktxp_user:="root"}
+: ${routeros_exporter_enable:="NO"}
+: ${routeros_exporter_user:="root"}
 
 # daemon
 pidfile="/var/run/${name}.pid"
 command="/usr/sbin/daemon"
-mktxp_command="/usr/local/bin/mktxp export"
+routeros_exporter_command="/usr/local/bin/routeros_exporter export"
 procname="daemon"
-command_args=" -c -f -P ${pidfile} ${mktxp_command}"
+command_args=" -c -f -P ${pidfile} ${routeros_exporter_command}"
 
 load_rc_config $name 
 run_rc_command "$1"
@@ -550,12 +576,12 @@ run_rc_command "$1"
 
 Let's save and then start the service as well as check on its' status:
 ```
-❯ sudo sysrc mktxp_enable="YES"
-❯ service mktxp start
-❯ service mktxp status
+❯ sudo sysrc routeros_exporter_enable="YES"
+❯ service routeros_exporter start
+❯ service routeros_exporter status
 
-❯ service mktxp status
-mktxp is running as pid 36704
+❯ service routeros_exporter status
+routeros_exporter is running as pid 36704
 ```
 
 ## Installing Development version

--- a/routeros_exporter/cli/config/config.py
+++ b/routeros_exporter/cli/config/config.py
@@ -1,0 +1,612 @@
+# coding=utf8
+# Copyright (c) 2020 Arseniy Kuznetsov
+##
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+##
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import os
+import sys
+import shutil
+from collections import namedtuple
+from configobj import ConfigObj
+from abc import ABCMeta, abstractmethod
+import importlib.resources
+from routeros_exporter.utils.utils import FSHelper
+
+
+''' RouterOS_Exporter conf file handling
+'''
+
+class CollectorKeys:
+    IDENTITY_COLLECTOR = 'IdentityCollector'
+    SYSTEM_RESOURCE_COLLECTOR = 'SystemResourceCollector'
+    HEALTH_COLLECTOR = 'HealthCollector'
+    PUBLIC_IP_ADDRESS_COLLECTOR = 'PublicIPAddressCollector'
+    NEIGHBOR_COLLECTOR = 'NeighborCollector'
+    DNS_COLLECTOR = 'DNSCollector'
+    PACKAGE_COLLECTOR = 'PackageCollector'
+    DHCP_COLLECTOR = 'DHCPCollector'
+    POOL_COLLECTOR = 'PoolCollector'
+    IP_CONNECTION_COLLECTOR = 'IPConnectionCollector'
+    INTERFACE_COLLECTOR = 'InterfaceCollector'
+    FIREWALL_COLLECTOR = 'FirewallCollector'
+    MONITOR_COLLECTOR = 'MonitorCollector'
+    W60G_COLLECTOR = 'W60gCollector'
+    POE_COLLECTOR = 'POECollector'
+    NETWATCH_COLLECTOR = 'NetwatchCollector'
+    ROUTE_COLLECTOR = 'RouteCollector'
+    WLAN_COLLECTOR = 'WLANCollector'
+    CAPSMAN_COLLECTOR = 'CapsmanCollector'
+    QUEUE_TREE_COLLECTOR = 'QueueTreeCollector'
+    QUEUE_SIMPLE_COLLECTOR = 'QueueSimpleCollector'
+    KID_CONTROL_DEVICE_COLLECTOR = 'KidControlCollector'
+    USER_COLLECTOR = 'UserCollector'
+    BFD_COLLECTOR = 'BFDCollector'
+    BGP_COLLECTOR = 'BGPCollector'
+    ROUTING_STATS_COLLECTOR = 'RoutingStatsCollector'
+    EOIP_COLLECTOR = 'EOIPCollector'
+    GRE_COLLECTOR = 'GRECollector'
+    IPIP_COLLECTOR = 'IPIPCollector'
+    IPSEC_COLLECTOR = 'IPSecCollector'
+    ADDRESS_LIST_COLLECTOR = 'AddressListCollector'
+    LTE_COLLECTOR = 'LTECollector'
+    SWITCH_PORT_COLLECTOR = 'SwitchPortCollector'
+    RouterOS_Exporter_COLLECTOR = 'RouterOSExporterCollector'
+    CERTIFICATE_COLLECTOR = 'CertificateCollector'
+    CONTAINER_COLLECTOR = "ContainerCollector"
+
+
+class RouterOSExporterConfigKeys:
+    ''' RouterOS_Exporter config file keys
+    '''
+    # Section Keys
+    ENABLED_KEY = 'enabled'
+    HOST_KEY = 'hostname'
+    PORT_KEY = 'port'
+    LISTEN_KEY = 'listen'
+    USER_KEY = 'username'
+    PASSWD_KEY = 'password'
+    CREDENTIALS_FILE_KEY = 'credentials_file'
+
+    SSL_KEY = 'use_ssl'
+    NO_SSL_CERTIFICATE = 'no_ssl_certificate'
+    SSL_CERTIFICATE_VERIFY = 'ssl_certificate_verify'
+    SSL_CHECK_HOSTNAME = 'ssl_check_hostname'
+    SSL_CA_FILE = 'ssl_ca_file'
+    PLAINTEXT_LOGIN_KEY = 'plaintext_login'
+
+    FE_HEALTH_KEY = 'health'
+    FE_PACKAGE_KEY = 'installed_packages'
+    FE_DHCP_KEY = 'dhcp'
+    FE_DHCP_LEASE_KEY = 'dhcp_lease'
+    FE_IP_CONNECTIONS_KEY = 'connections'
+    FE_CONNECTION_STATS_KEY = 'connection_stats'
+    FE_INTERFACE_KEY = 'interface'
+    
+    FE_ROUTE_KEY = 'route'
+    FE_DHCP_POOL_KEY = 'pool'
+    FE_FIREWALL_KEY = 'firewall'
+    FE_ADDRESS_LIST_KEY = 'address_list'
+    FE_NEIGHBOR_KEY = 'neighbor'
+    FE_DNS_KEY = 'dns'
+
+    FE_IPV6_ROUTE_KEY = 'ipv6_route'
+    FE_IPV6_DHCP_POOL_KEY = 'ipv6_pool'
+    FE_IPV6_FIREWALL_KEY = 'ipv6_firewall'
+    FE_IPV6_ADDRESS_LIST_KEY = 'ipv6_address_list'
+    FE_IPV6_NEIGHBOR_KEY = 'ipv6_neighbor'
+
+    FE_MONITOR_KEY = 'monitor'
+    FE_W60G_KEY = 'w60g'
+    FE_WIRELESS_KEY = 'wireless'
+    FE_WIRELESS_CLIENTS_KEY = 'wireless_clients'
+    FE_CAPSMAN_KEY = 'capsman'
+    FE_CAPSMAN_CLIENTS_KEY = 'capsman_clients'
+    FE_POE_KEY = 'poe'
+    FE_PUBLIC_IP_KEY = 'public_ip'
+    FE_NETWATCH_KEY = 'netwatch'
+
+    FE_EOIP_KEY = 'eoip'
+    FE_GRE_KEY = 'gre'
+    FE_IPIP_KEY = 'ipip'
+    FE_IPSEC_KEY = 'ipsec'
+    FE_LTE_KEY = "lte"
+    FE_SWITCH_PORT_KEY = "switch_port"
+
+    FE_USER_KEY = 'user'
+    FE_QUEUE_KEY = 'queue'
+    FE_BFD_KEY = 'bfd'
+    FE_BGP_KEY = 'bgp'
+
+    FE_REMOTE_DHCP_ENTRY = 'remote_dhcp_entry'
+    FE_REMOTE_CAPSMAN_ENTRY = 'remote_capsman_entry'
+
+    FE_CHECK_FOR_UPDATES = 'check_for_updates'
+
+    FE_KID_CONTROL_DEVICE = 'kid_control_assigned'
+    FE_KID_CONTROL_DYNAMIC = 'kid_control_dynamic'
+
+    FE_CONTAINER_KEY = 'container'
+
+    FE_CERTIFICATE_KEY = 'certificate'
+    FE_ROUTING_STATS_KEY = 'routing_stats'
+    FE_CUSTOM_LABELS_KEY = 'custom_labels'
+
+    RouterOS_Exporter_SOCKET_TIMEOUT = 'socket_timeout'
+    RouterOS_Exporter_INITIAL_DELAY = 'initial_delay_on_failure'
+    RouterOS_Exporter_MAX_DELAY = 'max_delay_on_failure'
+    RouterOS_Exporter_INC_DIV = 'delay_inc_div'
+    RouterOS_Exporter_BANDWIDTH_KEY = 'bandwidth'
+    RouterOS_Exporter_BANDWIDTH_TEST_INTERVAL = 'bandwidth_test_interval'
+    RouterOS_Exporter_VERBOSE_MODE = 'verbose_mode'
+    RouterOS_Exporter_MIN_COLLECT_INTERVAL = 'minimal_collect_interval'
+    RouterOS_Exporter_FETCH_IN_PARALLEL = 'fetch_routers_in_parallel'
+    RouterOS_Exporter_MAX_WORKER_THREADS = 'max_worker_threads'
+    RouterOS_Exporter_MAX_SCRAPE_DURATION = 'max_scrape_duration'
+    RouterOS_Exporter_TOTAL_MAX_SCRAPE_DURATION = 'total_max_scrape_duration'
+    RouterOS_Exporter_COMPACT_CONFIG = 'compact_default_conf_values'
+    RouterOS_Exporter_PROMETHEUS_HEADERS_DEDUPLICATION = 'prometheus_headers_deduplication'
+    RouterOS_Exporter_PERSISTENT_ROUTER_CONNECTION_POOL = 'persistent_router_connection_pool'
+    RouterOS_Exporter_PERSISTENT_DHCP_CACHE = 'persistent_dhcp_cache'
+
+    # UnRegistered entries placeholder
+    NO_ENTRIES_REGISTERED = 'NoEntriesRegistered'
+
+    RouterOS_Exporter_USE_COMMENTS_OVER_NAMES = 'use_comments_over_names'
+
+    # Base router id labels
+    ROUTERBOARD_NAME = 'routerboard_name'
+    ROUTERBOARD_ADDRESS = 'routerboard_address'
+
+    # Injected custom labels metadata ID 
+    CUSTOM_LABELS_METADATA_ID = '__custom__labels__metadata_id__'
+
+    # Default values    
+    DEFAULT_HOST_KEY = 'localhost'
+    DEFAULT_USER_KEY = 'user'
+    DEFAULT_PASSWORD_KEY = 'password'
+    DEFAULT_CREDENTIALS_FILE_KEY = ""
+
+    DEFAULT_SSL_CA_FILE = ""
+
+    DEFAULT_API_PORT = 8728
+    DEFAULT_API_SSL_PORT = 8729
+    DEFAULT_FE_REMOTE_DHCP_ENTRY = 'None'
+    DEFAULT_FE_REMOTE_CAPSMAN_ENTRY = 'None'
+    DEFAULT_FE_ADDRESS_LIST_KEY = 'None'
+    DEFAULT_FE_IPV6_ADDRESS_LIST_KEY = 'None'
+    DEFAULT_FE_CUSTOM_LABELS_KEY = 'None'
+
+    DEFAULT_RouterOS_Exporter_PORT = 49090
+    DEFAULT_RouterOS_Exporter_SOCKET_TIMEOUT = 2
+    DEFAULT_RouterOS_Exporter_INITIAL_DELAY = 120
+    DEFAULT_RouterOS_Exporter_MAX_DELAY = 900
+    DEFAULT_RouterOS_Exporter_INC_DIV = 5
+    DEFAULT_RouterOS_Exporter_BANDWIDTH_TEST_INTERVAL = 420
+    DEFAULT_RouterOS_Exporter_MIN_COLLECT_INTERVAL = 5
+    DEFAULT_RouterOS_Exporter_MAX_WORKER_THREADS = 5
+    DEFAULT_RouterOS_Exporter_MAX_SCRAPE_DURATION = 10
+    DEFAULT_RouterOS_Exporter_TOTAL_MAX_SCRAPE_DURATION = 30
+
+
+    BOOLEAN_KEYS_NO = {ENABLED_KEY, SSL_KEY, NO_SSL_CERTIFICATE, FE_CHECK_FOR_UPDATES, FE_KID_CONTROL_DEVICE, FE_KID_CONTROL_DYNAMIC,
+                       SSL_CERTIFICATE_VERIFY, FE_IPV6_ROUTE_KEY, FE_IPV6_DHCP_POOL_KEY, FE_IPV6_FIREWALL_KEY, FE_IPV6_NEIGHBOR_KEY, FE_CONNECTION_STATS_KEY, FE_BFD_KEY, FE_BGP_KEY,
+                       FE_EOIP_KEY, FE_GRE_KEY, FE_IPIP_KEY, FE_IPSEC_KEY, FE_LTE_KEY, FE_SWITCH_PORT_KEY, FE_ROUTING_STATS_KEY, FE_CERTIFICATE_KEY, FE_DNS_KEY, FE_CONTAINER_KEY, FE_W60G_KEY}
+
+    # Feature keys enabled by default
+    BOOLEAN_KEYS_YES = {PLAINTEXT_LOGIN_KEY, FE_DHCP_KEY, FE_HEALTH_KEY, FE_PACKAGE_KEY, FE_DHCP_LEASE_KEY, FE_IP_CONNECTIONS_KEY, FE_INTERFACE_KEY, 
+                        FE_ROUTE_KEY, FE_DHCP_POOL_KEY, FE_FIREWALL_KEY, FE_NEIGHBOR_KEY, FE_MONITOR_KEY, SSL_CHECK_HOSTNAME, RouterOS_Exporter_USE_COMMENTS_OVER_NAMES,
+                        FE_WIRELESS_KEY, FE_WIRELESS_CLIENTS_KEY, FE_CAPSMAN_KEY, FE_CAPSMAN_CLIENTS_KEY, FE_POE_KEY,
+                        FE_NETWATCH_KEY, FE_PUBLIC_IP_KEY, FE_USER_KEY, FE_QUEUE_KEY}
+
+    SYSTEM_BOOLEAN_KEYS_YES = {RouterOS_Exporter_PERSISTENT_ROUTER_CONNECTION_POOL, RouterOS_Exporter_PERSISTENT_DHCP_CACHE}
+    SYSTEM_BOOLEAN_KEYS_NO = {RouterOS_Exporter_BANDWIDTH_KEY, RouterOS_Exporter_VERBOSE_MODE, RouterOS_Exporter_FETCH_IN_PARALLEL, RouterOS_Exporter_COMPACT_CONFIG, RouterOS_Exporter_PROMETHEUS_HEADERS_DEDUPLICATION}
+
+    STR_KEYS = (HOST_KEY, USER_KEY, PASSWD_KEY, CREDENTIALS_FILE_KEY, SSL_CA_FILE, FE_REMOTE_DHCP_ENTRY, FE_REMOTE_CAPSMAN_ENTRY, FE_ADDRESS_LIST_KEY, FE_IPV6_ADDRESS_LIST_KEY, FE_CUSTOM_LABELS_KEY)
+    INT_KEYS =  ()
+    RouterOS_Exporter_INT_KEYS = (PORT_KEY, RouterOS_Exporter_SOCKET_TIMEOUT, RouterOS_Exporter_INITIAL_DELAY, RouterOS_Exporter_MAX_DELAY,
+                      RouterOS_Exporter_INC_DIV, RouterOS_Exporter_BANDWIDTH_TEST_INTERVAL, RouterOS_Exporter_MIN_COLLECT_INTERVAL,
+                      RouterOS_Exporter_MAX_WORKER_THREADS, RouterOS_Exporter_MAX_SCRAPE_DURATION, RouterOS_Exporter_TOTAL_MAX_SCRAPE_DURATION)
+
+    # RouterOS_Exporter configs entry names
+    DEFAULT_ENTRY_KEY = 'default'
+    RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY = 'new_default_parameters'
+    RouterOS_Exporter_CONFIG_ENTRY_NAME = 'RouterOS_Exporter'
+    RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY = 'new_system_parameters'
+
+
+class ConfigEntry:
+    RouterOSExporterConfigEntry = namedtuple('RouterOSExporterConfigEntry', [RouterOSExporterConfigKeys.ENABLED_KEY, RouterOSExporterConfigKeys.HOST_KEY, RouterOSExporterConfigKeys.PORT_KEY,
+                                                       RouterOSExporterConfigKeys.USER_KEY, RouterOSExporterConfigKeys.PASSWD_KEY, RouterOSExporterConfigKeys.CREDENTIALS_FILE_KEY,
+                                                       RouterOSExporterConfigKeys.SSL_KEY, RouterOSExporterConfigKeys.NO_SSL_CERTIFICATE, RouterOSExporterConfigKeys.SSL_CERTIFICATE_VERIFY, RouterOSExporterConfigKeys.SSL_CHECK_HOSTNAME, RouterOSExporterConfigKeys.SSL_CA_FILE, RouterOSExporterConfigKeys.PLAINTEXT_LOGIN_KEY,
+                                                       RouterOSExporterConfigKeys.FE_DHCP_KEY, RouterOSExporterConfigKeys.FE_HEALTH_KEY, RouterOSExporterConfigKeys.FE_PACKAGE_KEY, RouterOSExporterConfigKeys.FE_DHCP_LEASE_KEY, RouterOSExporterConfigKeys.FE_INTERFACE_KEY,
+                                                       RouterOSExporterConfigKeys.FE_MONITOR_KEY, RouterOSExporterConfigKeys.FE_W60G_KEY, RouterOSExporterConfigKeys.FE_WIRELESS_KEY, RouterOSExporterConfigKeys.FE_WIRELESS_CLIENTS_KEY,
+                                                       RouterOSExporterConfigKeys.FE_IP_CONNECTIONS_KEY, RouterOSExporterConfigKeys.FE_CONNECTION_STATS_KEY, RouterOSExporterConfigKeys.FE_CAPSMAN_KEY, RouterOSExporterConfigKeys.FE_CAPSMAN_CLIENTS_KEY, RouterOSExporterConfigKeys.FE_POE_KEY, 
+                                                       RouterOSExporterConfigKeys.FE_NETWATCH_KEY, RouterOSExporterConfigKeys.RouterOS_Exporter_USE_COMMENTS_OVER_NAMES, RouterOSExporterConfigKeys.FE_PUBLIC_IP_KEY,
+                                                       RouterOSExporterConfigKeys.FE_ROUTE_KEY, RouterOSExporterConfigKeys.FE_DHCP_POOL_KEY, RouterOSExporterConfigKeys.FE_FIREWALL_KEY, RouterOSExporterConfigKeys.FE_ADDRESS_LIST_KEY, RouterOSExporterConfigKeys.FE_NEIGHBOR_KEY, RouterOSExporterConfigKeys.FE_DNS_KEY,
+                                                       RouterOSExporterConfigKeys.FE_IPV6_ROUTE_KEY, RouterOSExporterConfigKeys.FE_IPV6_DHCP_POOL_KEY, RouterOSExporterConfigKeys.FE_IPV6_FIREWALL_KEY, RouterOSExporterConfigKeys.FE_IPV6_ADDRESS_LIST_KEY, RouterOSExporterConfigKeys.FE_IPV6_NEIGHBOR_KEY,                                               
+                                                       RouterOSExporterConfigKeys.FE_USER_KEY, RouterOSExporterConfigKeys.FE_QUEUE_KEY, RouterOSExporterConfigKeys.FE_REMOTE_DHCP_ENTRY, RouterOSExporterConfigKeys.FE_REMOTE_CAPSMAN_ENTRY, RouterOSExporterConfigKeys.FE_CHECK_FOR_UPDATES, RouterOSExporterConfigKeys.FE_BFD_KEY, RouterOSExporterConfigKeys.FE_BGP_KEY,
+                                                       RouterOSExporterConfigKeys.FE_KID_CONTROL_DEVICE, RouterOSExporterConfigKeys.FE_KID_CONTROL_DYNAMIC, RouterOSExporterConfigKeys.FE_EOIP_KEY, RouterOSExporterConfigKeys.FE_GRE_KEY, RouterOSExporterConfigKeys.FE_IPIP_KEY, RouterOSExporterConfigKeys.FE_LTE_KEY, RouterOSExporterConfigKeys.FE_IPSEC_KEY, RouterOSExporterConfigKeys.FE_SWITCH_PORT_KEY,
+                                                       RouterOSExporterConfigKeys.FE_ROUTING_STATS_KEY, RouterOSExporterConfigKeys.FE_CERTIFICATE_KEY, RouterOSExporterConfigKeys.FE_CONTAINER_KEY,
+                                                       RouterOSExporterConfigKeys.FE_CUSTOM_LABELS_KEY
+                                                       ])
+    RouterOSExporterSystemEntry = namedtuple('RouterOSExporterSystemEntry', [RouterOSExporterConfigKeys.PORT_KEY, RouterOSExporterConfigKeys.LISTEN_KEY, RouterOSExporterConfigKeys.RouterOS_Exporter_SOCKET_TIMEOUT,
+                                                       RouterOSExporterConfigKeys.RouterOS_Exporter_INITIAL_DELAY, RouterOSExporterConfigKeys.RouterOS_Exporter_MAX_DELAY,
+                                                       RouterOSExporterConfigKeys.RouterOS_Exporter_INC_DIV, RouterOSExporterConfigKeys.RouterOS_Exporter_BANDWIDTH_KEY,
+                                                       RouterOSExporterConfigKeys.RouterOS_Exporter_VERBOSE_MODE, RouterOSExporterConfigKeys.RouterOS_Exporter_BANDWIDTH_TEST_INTERVAL,
+                                                       RouterOSExporterConfigKeys.RouterOS_Exporter_MIN_COLLECT_INTERVAL, RouterOSExporterConfigKeys.RouterOS_Exporter_FETCH_IN_PARALLEL,
+                                                       RouterOSExporterConfigKeys.RouterOS_Exporter_MAX_WORKER_THREADS, RouterOSExporterConfigKeys.RouterOS_Exporter_MAX_SCRAPE_DURATION, 
+                                                       RouterOSExporterConfigKeys.RouterOS_Exporter_TOTAL_MAX_SCRAPE_DURATION, RouterOSExporterConfigKeys.RouterOS_Exporter_COMPACT_CONFIG, 
+                                                       RouterOSExporterConfigKeys.RouterOS_Exporter_PROMETHEUS_HEADERS_DEDUPLICATION, RouterOSExporterConfigKeys.RouterOS_Exporter_PERSISTENT_ROUTER_CONNECTION_POOL,
+                                                       RouterOSExporterConfigKeys.RouterOS_Exporter_PERSISTENT_DHCP_CACHE])
+
+
+class OSConfig(metaclass=ABCMeta):
+    ''' OS-related config
+    '''
+    @staticmethod
+    def os_config():
+        ''' Factory method
+        '''
+        if sys.platform == 'linux':
+            return LinuxConfig()
+        elif sys.platform == 'darwin':
+            return OSXConfig()
+        elif sys.platform.startswith('freebsd'):
+            return FreeBSDConfig()
+        else:
+            print(f'Non-supported platform: {sys.platform}')
+            return None
+
+    @property
+    @abstractmethod
+    def routeros_exporter_user_dir_path(self):
+        pass
+
+
+class FreeBSDConfig(OSConfig):
+    ''' FreeBSD-related config
+    '''
+    @property
+    def routeros_exporter_user_dir_path(self):
+        return FSHelper.full_path('~/routeros_exporter')
+
+
+class OSXConfig(OSConfig):
+    ''' OSX-related config
+    '''
+    @property
+    def routeros_exporter_user_dir_path(self):
+        return FSHelper.full_path('~/routeros_exporter')
+
+
+class LinuxConfig(OSConfig):
+    ''' Linux-related config
+    '''
+    @property
+    def routeros_exporter_user_dir_path(self):
+        return '/app'
+
+
+class CustomConfig(OSConfig):
+    ''' Custom config
+    '''
+    def __init__(self, path):
+        self._user_dir_path = path
+
+    @property
+    def routeros_exporter_user_dir_path(self):
+        return FSHelper.full_path(self._user_dir_path)
+
+# Mock system entry to enable running tests
+mockSystemEntry = ConfigEntry.RouterOSExporterSystemEntry(
+            port=RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_PORT,
+            listen=f'0.0.0.0:{RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_PORT}',
+            socket_timeout=RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_SOCKET_TIMEOUT,
+            initial_delay_on_failure=RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_INITIAL_DELAY,
+            max_delay_on_failure=RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_MAX_DELAY,
+            delay_inc_div=RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_INC_DIV,
+            bandwidth=False,
+            verbose_mode=False,
+            bandwidth_test_interval=RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_BANDWIDTH_TEST_INTERVAL,
+            minimal_collect_interval=RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_MIN_COLLECT_INTERVAL,
+            fetch_routers_in_parallel=False,
+            max_worker_threads=RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_MAX_WORKER_THREADS,
+            max_scrape_duration=RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_MAX_SCRAPE_DURATION,
+            total_max_scrape_duration=RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_TOTAL_MAX_SCRAPE_DURATION,
+            compact_default_conf_values=False,
+            prometheus_headers_deduplication=False,
+            persistent_router_connection_pool=True,
+            persistent_dhcp_cache=True
+        )
+
+class RouterOSExporterConfigHandler:
+    # two-phase init
+    def __init__(self):
+        # to be re-inisialised properly in the second phase
+        self.system_entry = mockSystemEntry
+
+    # two-phase init, to enable custom config
+    def __call__(self, os_config = None):
+        self.os_config = os_config if os_config else OSConfig.os_config()
+        if not self.os_config:
+            sys.exit(1)
+
+        # routeros_exporter user config folder
+        if not os.path.exists(self.os_config.routeros_exporter_user_dir_path):
+            os.makedirs(self.os_config.routeros_exporter_user_dir_path)
+
+        # if needed, stage the user config data
+        # 在 Linux 环境下使用 device.conf，其他环境使用 routeros_exporter.conf
+        conf_filename = 'device.conf' if sys.platform == 'linux' else 'routeros_exporter.conf'
+        self.usr_conf_data_path = os.path.join(
+            self.os_config.routeros_exporter_user_dir_path, conf_filename)
+        self.routeros_exporter_conf_path = os.path.join(
+            self.os_config.routeros_exporter_user_dir_path, 'exporter.conf')
+
+        self._create_os_path(self.usr_conf_data_path,
+                             'cli/config/routeros_exporter.conf')
+        self._create_os_path(self.routeros_exporter_conf_path,
+                             'cli/config/_routeros_exporter.conf')
+
+        self.re_compiled = {}
+
+        self._read_from_disk()
+
+        self.default_config_entry_reader = self._default_config_entry_reader()
+        self.system_entry = self._system_entry()
+
+    # RouterOS_Exporter entries
+    def registered_entries(self):
+        ''' All RouterOS_Exporter registered entries
+        '''
+        return (entry_name for entry_name in self.config.keys() if entry_name not in
+                (RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY, RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY))
+
+    def registered_entry(self, entry_name):
+        ''' A specific RouterOS_Exporter registered entry by name
+        '''
+        return self.config.get(entry_name)
+
+    def config_entry(self, entry_name):
+        ''' Given an entry name, reads and returns the entry info
+        '''
+        entry_reader = self._config_entry_reader(entry_name)
+        return ConfigEntry.RouterOSExporterConfigEntry(**entry_reader) if entry_reader else None
+
+    # Helpers
+    def _system_entry(self):
+        ''' RouterOS_Exporter internal config entry
+        '''
+        _entry_reader = self._system_entry_reader()
+        return ConfigEntry.RouterOSExporterSystemEntry(**_entry_reader)
+
+    def _read_from_disk(self):
+        ''' (Force-)Read conf data from disk
+        '''
+        self.config = ConfigObj(self.usr_conf_data_path, indent_type = '    ', encoding='utf-8')
+        self.config.preserve_comments = True
+
+        self._config = ConfigObj(self.routeros_exporter_conf_path, indent_type = '    ', encoding='utf-8')
+        self._config.preserve_comments = True
+
+    def _create_os_path(self, os_path, resource_path):
+        if not os.path.exists(os_path):
+            # stage from the conf templates
+            ref = importlib.resources.files('routeros_exporter') / resource_path
+            with importlib.resources.as_file(ref) as path:
+                shutil.copy(path, os_path)
+
+    def _system_entry_reader(self):
+        system_entry_reader = {}
+        entry_name = RouterOSExporterConfigKeys.RouterOS_Exporter_CONFIG_ENTRY_NAME
+        new_keys, new_keys_values = [], {}
+
+        if not self._config.get(RouterOSExporterConfigKeys.RouterOS_Exporter_CONFIG_ENTRY_NAME):
+            self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_CONFIG_ENTRY_NAME] = {}
+        if not self._config.get(RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY):
+            self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY] = {}
+
+        for key in RouterOSExporterConfigKeys.RouterOS_Exporter_INT_KEYS:
+            if self._config[entry_name].get(key):
+                system_entry_reader[key] = self._config[entry_name].as_int(key)
+            elif self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY].get(key):
+                system_entry_reader[key] = self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY].as_int(key)
+            else:
+                system_entry_reader[key] = self._default_value_for_key(key)
+                if key not in (RouterOSExporterConfigKeys.PORT_KEY):  # Port key has been depricated
+                    new_keys.append(key) # read from disk next time
+                    new_keys_values[key] = system_entry_reader[key]
+
+        for key in RouterOSExporterConfigKeys.SYSTEM_BOOLEAN_KEYS_NO.union(RouterOSExporterConfigKeys.SYSTEM_BOOLEAN_KEYS_YES):
+            if self._config[entry_name].get(key) is not None:
+                system_entry_reader[key] = self._config[entry_name].as_bool(key)
+            elif self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY].get(key) is not None:
+                system_entry_reader[key] = self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY].as_bool(key)
+            else:
+                system_entry_reader[key] = True if key in RouterOSExporterConfigKeys.SYSTEM_BOOLEAN_KEYS_YES else False
+                new_keys.append(key) # read from disk next time
+                new_keys_values[key] = system_entry_reader[key]
+
+        # listen
+        if self._config[entry_name].get(RouterOSExporterConfigKeys.LISTEN_KEY):
+            system_entry_reader[RouterOSExporterConfigKeys.LISTEN_KEY] = self._config[entry_name].get(RouterOSExporterConfigKeys.LISTEN_KEY)
+        elif self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY].get(RouterOSExporterConfigKeys.LISTEN_KEY):
+            system_entry_reader[RouterOSExporterConfigKeys.LISTEN_KEY] = self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY].get(RouterOSExporterConfigKeys.LISTEN_KEY)
+        else:
+            system_entry_reader[RouterOSExporterConfigKeys.LISTEN_KEY] = f'0.0.0.0:{system_entry_reader.get(RouterOSExporterConfigKeys.PORT_KEY, RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_PORT)}'
+            new_keys.append(RouterOSExporterConfigKeys.LISTEN_KEY) # read from disk next time
+            new_keys_values[RouterOSExporterConfigKeys.LISTEN_KEY] = system_entry_reader[RouterOSExporterConfigKeys.LISTEN_KEY]
+
+        if new_keys:
+            self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY].update(new_keys_values)
+            self._config.comments[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY] = \
+                ['', '# The section below contains the latest system parameters introduced by RouterOS_Exporter',
+                 f'# For organizational purposes, you can move these parameters to the [{RouterOSExporterConfigKeys.RouterOS_Exporter_CONFIG_ENTRY_NAME}] section']
+            try:
+                self._config[entry_name].pop(RouterOSExporterConfigKeys.PORT_KEY, None) # Port key has been depricated
+                self._config.write()
+                if self._config[entry_name].as_bool(RouterOSExporterConfigKeys.RouterOS_Exporter_VERBOSE_MODE):
+                    print(f'Updated system entry {entry_name} with new system keys {new_keys}')
+            except Exception as exc:
+                print(f'Error updating system entry {entry_name} with new system keys {new_keys}: {exc}')
+                print('Please update _routeros_exporter.conf to its latest version manually')
+
+        return system_entry_reader
+
+    def _config_entry_reader(self, entry_name):
+        config_entry_reader = {}
+        compact_config = self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_CONFIG_ENTRY_NAME].as_bool(RouterOSExporterConfigKeys.RouterOS_Exporter_COMPACT_CONFIG)
+        drop_keys = []
+
+        for key in RouterOSExporterConfigKeys.BOOLEAN_KEYS_NO.union(RouterOSExporterConfigKeys.BOOLEAN_KEYS_YES):
+            if self.config[entry_name].get(key) is not None:
+                config_entry_reader[key] = self.config[entry_name].as_bool(key)
+                if compact_config and config_entry_reader[key] == self.default_config_entry_reader[key]:
+                    drop_keys.append(key)
+            else:
+                config_entry_reader[key] = self.default_config_entry_reader[key]
+
+        for key in RouterOSExporterConfigKeys.STR_KEYS:
+            if self.config[entry_name].get(key):
+                config_entry_reader[key] = self.config[entry_name].get(key)
+                if key is RouterOSExporterConfigKeys.PASSWD_KEY and type(config_entry_reader[key]) is list:
+                    config_entry_reader[key] = ','.join(config_entry_reader[key])         
+
+                if compact_config and config_entry_reader[key] == self.default_config_entry_reader[key]:
+                    drop_keys.append(key)
+            else:
+                config_entry_reader[key] = self.default_config_entry_reader[key]
+
+        for key in RouterOSExporterConfigKeys.INT_KEYS:
+            if self.config[entry_name].get(key):
+                config_entry_reader[key] = self.config[entry_name].as_int(key)
+                if compact_config and config_entry_reader[key] == self.default_config_entry_reader[key]:
+                    drop_keys.append(key)                
+            else:
+                config_entry_reader[key] = self.default_config_entry_reader[key]
+
+        # port
+        if self.config[entry_name].get(RouterOSExporterConfigKeys.PORT_KEY):
+            config_entry_reader[RouterOSExporterConfigKeys.PORT_KEY] = self.config[entry_name].as_int(RouterOSExporterConfigKeys.PORT_KEY)
+            if compact_config and config_entry_reader[RouterOSExporterConfigKeys.PORT_KEY] == self.default_config_entry_reader[RouterOSExporterConfigKeys.PORT_KEY]:
+                drop_keys.append(RouterOSExporterConfigKeys.PORT_KEY)    
+        else:
+            config_entry_reader[RouterOSExporterConfigKeys.PORT_KEY] = self.default_config_entry_reader[RouterOSExporterConfigKeys.PORT_KEY]
+
+        # If allowed, compact routeros_exporter.conf entry
+        if drop_keys and compact_config:
+            for key in drop_keys:
+                self.config[entry_name].pop(key, None)
+            try:
+                self.config.write()
+                if self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_CONFIG_ENTRY_NAME].as_bool(RouterOSExporterConfigKeys.RouterOS_Exporter_VERBOSE_MODE):
+                    print(f'compacted router entry {entry_name} for default values of the feature keys {drop_keys}')                    
+            except Exception as exc:
+                print(f'Error compacting router entry {entry_name} for default values of feature keys {drop_keys}: {exc}')
+                print(f'Error compacting router entry {entry_name} for default values of feature keys {drop_keys}: {exc}')
+                print('Please compact routeros_exporter.conf manually')
+
+        return config_entry_reader
+
+    def _default_config_entry_reader(self):
+        default_config_entry_reader = {}
+        new_keys, new_keys_values = [], {}
+
+        if not self.config.get(RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY):
+            self.config[RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY] = {}
+        if not self.config.get(RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY):
+            self.config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY] = {}
+
+        for key in RouterOSExporterConfigKeys.BOOLEAN_KEYS_NO.union(RouterOSExporterConfigKeys.BOOLEAN_KEYS_YES):
+            if self.config[RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY].get(key) is not None:
+                default_config_entry_reader[key] = self.config[RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY].as_bool(key)
+            elif self.config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY].get(key) is not None:
+                default_config_entry_reader[key] = self.config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY].as_bool(key)
+            else:
+                default_config_entry_reader[key] = True if key in RouterOSExporterConfigKeys.BOOLEAN_KEYS_YES else False
+                new_keys.append(key) # read from disk next time
+                new_keys_values[key] = default_config_entry_reader[key]
+
+        for key in RouterOSExporterConfigKeys.STR_KEYS:
+            if self.config[RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY].get(key) is not None:
+                default_config_entry_reader[key] = self.config[RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY].get(key)
+            elif self.config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY].get(key) is not None:
+                default_config_entry_reader[key] = self.config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY].get(key)
+            else:
+                default_config_entry_reader[key] = self._default_value_for_key(key)
+                new_keys.append(key) # read from disk next time
+                new_keys_values[key] = default_config_entry_reader[key]
+
+        for key in RouterOSExporterConfigKeys.INT_KEYS:
+            if self.config[RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY].get(key):
+                default_config_entry_reader[key] = self.config[RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY].as_int(key)
+            elif self.config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY].get(key):
+                default_config_entry_reader[key] = self.config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY].as_int(key)
+            else:
+                default_config_entry_reader[key] = self._default_value_for_key(key)
+                new_keys.append(key) # read from disk next time
+                new_keys_values[key] = default_config_entry_reader[key]
+
+        # port
+        if self.config[RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY].get(RouterOSExporterConfigKeys.PORT_KEY):
+            default_config_entry_reader[RouterOSExporterConfigKeys.PORT_KEY] = self.config[RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY].as_int(RouterOSExporterConfigKeys.PORT_KEY)
+        elif self.config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY].get(RouterOSExporterConfigKeys.PORT_KEY):
+            default_config_entry_reader[RouterOSExporterConfigKeys.PORT_KEY] = self.config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY].as_int(RouterOSExporterConfigKeys.PORT_KEY)
+        else:
+            default_config_entry_reader[RouterOSExporterConfigKeys.PORT_KEY] = self._default_value_for_key(
+                RouterOSExporterConfigKeys.SSL_KEY, default_config_entry_reader[RouterOSExporterConfigKeys.SSL_KEY])
+            new_keys.append(RouterOSExporterConfigKeys.PORT_KEY) # read from disk next time
+            new_keys_values[RouterOSExporterConfigKeys.PORT_KEY] = default_config_entry_reader[RouterOSExporterConfigKeys.PORT_KEY]
+
+        if new_keys:
+            self.config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY].update(new_keys_values)
+            self.config.comments[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY] = \
+                ['', '# The section below contains the latest default parameters introduced by RouterOS_Exporter',
+                 f'# For organizational purposes, you can move these parameters to the [{RouterOSExporterConfigKeys.DEFAULT_ENTRY_KEY}] section']
+            try:
+                self.config.write()
+                if self._config[RouterOSExporterConfigKeys.RouterOS_Exporter_CONFIG_ENTRY_NAME].as_bool(RouterOSExporterConfigKeys.RouterOS_Exporter_VERBOSE_MODE):
+                    print(f'Updated default router entry with new feature keys {new_keys}')
+            except Exception as exc:
+                print(f'Error updating default router entry with new feature keys {new_keys}: {exc}')
+                print('Please update routeros_exporter.conf to its latest version manually')
+
+        return default_config_entry_reader
+
+    def _default_value_for_key(self, key, value=None):
+        return {
+            RouterOSExporterConfigKeys.SSL_KEY: lambda value: RouterOSExporterConfigKeys.DEFAULT_API_SSL_PORT if value else RouterOSExporterConfigKeys.DEFAULT_API_PORT,
+            RouterOSExporterConfigKeys.HOST_KEY: lambda _: RouterOSExporterConfigKeys.DEFAULT_HOST_KEY,
+            RouterOSExporterConfigKeys.USER_KEY: lambda _: RouterOSExporterConfigKeys.DEFAULT_USER_KEY,
+            RouterOSExporterConfigKeys.PASSWD_KEY: lambda _: RouterOSExporterConfigKeys.DEFAULT_PASSWORD_KEY,
+            RouterOSExporterConfigKeys.CREDENTIALS_FILE_KEY: lambda _: RouterOSExporterConfigKeys.DEFAULT_CREDENTIALS_FILE_KEY,
+            RouterOSExporterConfigKeys.FE_CUSTOM_LABELS_KEY: lambda _: RouterOSExporterConfigKeys.DEFAULT_FE_CUSTOM_LABELS_KEY,
+            RouterOSExporterConfigKeys.PORT_KEY: lambda _: RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_PORT,
+            RouterOSExporterConfigKeys.SSL_CA_FILE: lambda _: RouterOSExporterConfigKeys.DEFAULT_SSL_CA_FILE,
+            RouterOSExporterConfigKeys.FE_REMOTE_DHCP_ENTRY:  lambda _: RouterOSExporterConfigKeys.DEFAULT_FE_REMOTE_DHCP_ENTRY,
+            RouterOSExporterConfigKeys.FE_REMOTE_CAPSMAN_ENTRY:  lambda _: RouterOSExporterConfigKeys.DEFAULT_FE_REMOTE_CAPSMAN_ENTRY,
+            RouterOSExporterConfigKeys.FE_ADDRESS_LIST_KEY: lambda _: RouterOSExporterConfigKeys.DEFAULT_FE_ADDRESS_LIST_KEY,
+            RouterOSExporterConfigKeys.FE_IPV6_ADDRESS_LIST_KEY: lambda _: RouterOSExporterConfigKeys.DEFAULT_FE_IPV6_ADDRESS_LIST_KEY,
+            RouterOSExporterConfigKeys.RouterOS_Exporter_SOCKET_TIMEOUT: lambda _: RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_SOCKET_TIMEOUT,
+            RouterOSExporterConfigKeys.RouterOS_Exporter_INITIAL_DELAY: lambda _: RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_INITIAL_DELAY,
+            RouterOSExporterConfigKeys.RouterOS_Exporter_MAX_DELAY: lambda _: RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_MAX_DELAY,
+            RouterOSExporterConfigKeys.RouterOS_Exporter_INC_DIV: lambda _: RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_INC_DIV,
+            RouterOSExporterConfigKeys.RouterOS_Exporter_BANDWIDTH_TEST_INTERVAL: lambda _: RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_BANDWIDTH_TEST_INTERVAL,
+            RouterOSExporterConfigKeys.RouterOS_Exporter_MIN_COLLECT_INTERVAL: lambda _: RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_MIN_COLLECT_INTERVAL,
+            RouterOSExporterConfigKeys.RouterOS_Exporter_MAX_WORKER_THREADS: lambda _: RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_MAX_WORKER_THREADS,
+            RouterOSExporterConfigKeys.RouterOS_Exporter_MAX_SCRAPE_DURATION: lambda _: RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_MAX_SCRAPE_DURATION,
+            RouterOSExporterConfigKeys.RouterOS_Exporter_TOTAL_MAX_SCRAPE_DURATION: lambda _: RouterOSExporterConfigKeys.DEFAULT_RouterOS_Exporter_TOTAL_MAX_SCRAPE_DURATION,
+            RouterOSExporterConfigKeys.RouterOS_Exporter_PERSISTENT_DHCP_CACHE: lambda _: True,
+        }[key](value)
+
+
+# Simplest possible Singleton impl
+config_handler = RouterOSExporterConfigHandler()

--- a/routeros_exporter/cli/dispatch.py
+++ b/routeros_exporter/cli/dispatch.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+
+import subprocess
+from routeros_exporter.cli.config.config import config_handler
+from routeros_exporter.cli.options import RouterOSExporterOptionsParser, RouterOSExporterCommands
+from routeros_exporter.flow.processor.base_proc import ExportProcessor, OutputProcessor
+
+
+class RouterOSExporterDispatcher:
+    ''' Base RouterOS_Exporter Commands Dispatcher
+    '''
+    def __init__(self):
+        self.option_parser = RouterOSExporterOptionsParser()
+
+    # Dispatcher
+    def dispatch(self):
+        args = self.option_parser.parse_options()
+
+        if args['sub_cmd'] == RouterOSExporterCommands.INFO:
+            self.print_info()
+
+        elif args['sub_cmd'] == RouterOSExporterCommands.SHOW:
+            self.show_entries(args)
+
+        elif args['sub_cmd'] == RouterOSExporterCommands.ENTRY:
+            self.create_entry(args)
+
+        elif args['sub_cmd'] == RouterOSExporterCommands.EXPORT:
+            self.start_export(args)
+
+        elif args['sub_cmd'] == RouterOSExporterCommands.PRINT:
+            self.print(args)
+
+        elif args['sub_cmd'] == RouterOSExporterCommands.EDIT:
+            self.edit_entry(args)
+
+        else:
+            # nothing to dispatch
+            return False
+
+        return True
+
+    # Dispatched methods
+    def print_info(self):
+        ''' Prints RouterOS_Exporter general info
+        '''
+        print(f'{self.option_parser.script_name}: {self.option_parser.description}')
+
+    def show_entries(self, args):
+        if args['config']:
+            print(f'RouterOS_Exporter data config: {config_handler.usr_conf_data_path}')
+            print(f'RouterOS_Exporter internal config: {config_handler.routeros_exporter_conf_path}')
+        else:
+            for entryname in config_handler.registered_entries():
+                if args['entry_name'] and entryname != args['entry_name']:
+                    continue
+                entry = config_handler.config_entry(entryname)
+                print(f'[{entryname}]')
+                divider_fields = set(['username', 'use_ssl', 'dhcp'])
+                for field in entry._fields:
+                    if field == 'password':
+                        print(f'    {field}: {"*" * len(entry.password)}')
+                    else:
+                        if field in divider_fields:
+                            print()
+                        print(f'    {field}: {getattr(entry, field)}')
+                print('\n')
+
+    def edit_entry(self, args):
+        editor = args['editor']
+        if not editor:
+            print(f'No editor to edit the following file with: {config_handler.usr_conf_data_path}')
+        if args['internal']:
+            subprocess.check_call([editor, config_handler.routeros_exporter_conf_path])
+        else:
+            subprocess.check_call([editor, config_handler.usr_conf_data_path])
+
+    def create_entry(self, args):
+        ''' 创建新的 RouterOS 配置条目 '''
+        entry_name = args['entry_name']
+
+        # 检查条目是否已存在
+        if config_handler.registered_entry(entry_name):
+            print(f'错误: 配置条目 [{entry_name}] 已存在')
+            print(f'使用 "routeros_exporter edit" 命令编辑现有条目')
+            return
+
+        # 创建新条目
+        config_handler.config[entry_name] = {}
+
+        # 添加用户提供的参数
+        if args.get('hostname'):
+            config_handler.config[entry_name]['hostname'] = args['hostname']
+        if args.get('port'):
+            config_handler.config[entry_name]['port'] = args['port']
+        if args.get('username'):
+            config_handler.config[entry_name]['username'] = args['username']
+        if args.get('password'):
+            config_handler.config[entry_name]['password'] = args['password']
+
+        # 添加注释
+        config_handler.config.comments[entry_name] = [
+            '',
+            f'# RouterOS device configuration for {entry_name}',
+            '# Customize settings below or inherit from [default] section'
+        ]
+
+        # 保存配置文件
+        try:
+            config_handler.config.write()
+            print(f'成功创建配置条目 [{entry_name}]')
+            print(f'配置文件位置: {config_handler.usr_conf_data_path}')
+            print(f'\n使用以下命令编辑完整配置:')
+            print(f'  routeros_exporter edit')
+        except Exception as exc:
+            print(f'错误: 无法保存配置文件: {exc}')
+
+    def start_export(self, args):
+        ExportProcessor.start()
+
+    def print(self, args):
+        if args['wifi_clients']:
+            OutputProcessor.wifi_clients(args['entry_name'])
+
+        elif args['capsman_clients']:
+            OutputProcessor.capsman_clients(args['entry_name'])
+
+        elif args['dhcp_clients']:
+            OutputProcessor.dhcp_clients(args['entry_name'])
+
+        elif args['conn_stats']:
+            OutputProcessor.conn_stats(args['entry_name'])
+
+        elif args['kid_control']:
+            OutputProcessor.kid_control(args['entry_name'])
+
+        elif args['address_lists']:
+            OutputProcessor.address_lists(args['entry_name'], args['address_lists'])
+
+        elif args['netwatch']:
+            OutputProcessor.netwatch(args['entry_name'])
+
+        else:
+            print("Select metric option(s) to print out, or run 'routeros_exporter print -h' to find out more")
+
+def main():
+    RouterOSExporterDispatcher().dispatch()
+
+if __name__ == '__main__':
+    main()

--- a/routeros_exporter/cli/options.py
+++ b/routeros_exporter/cli/options.py
@@ -1,0 +1,311 @@
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+
+import os
+from argparse import ArgumentParser, HelpFormatter
+from routeros_exporter.cli.config.config import config_handler, RouterOSExporterConfigKeys, CustomConfig
+from routeros_exporter.utils.utils import FSHelper, UniquePartialMatchList, run_cmd
+from importlib.metadata import version as Version
+
+class RouterOSExporterCommands:
+    INFO = 'info'
+    EDIT = 'edit'
+    ENTRY = 'entry'
+    EXPORT = 'export'
+    PRINT = 'print'
+    SHOW = 'show'
+
+    @classmethod
+    def commands_meta(cls):
+        return ''.join(('{',
+                        f'{cls.INFO}, ',
+                        f'{cls.EDIT}, ',
+                        f'{cls.ENTRY}, ',
+                        f'{cls.EXPORT}, ',
+                        f'{cls.PRINT}, ',
+                        f'{cls.SHOW}',
+                        '}'))
+
+class RouterOSExporterOptionsParser:
+    ''' Base RouterOS_Exporter Options Parser
+    '''
+    def __init__(self):
+        self._script_name = f'RouterOS_Exporter'
+        version = Version('routeros_exporter')
+        self._description =  \
+f'''
+Prometheus Exporter for Mikrotik RouterOS, version {version}
+Supports gathering metrics across multiple RouterOS devices, all easily configurable via built-in CLI interface.
+Comes along with a dedicated Grafana dashboard (https://grafana.com/grafana/dashboards/13679)
+Selected metrics info can be printed on the command line. For more information, run: 'routeros_exporter -h'
+'''
+
+    @property
+    def description(self):
+        return self._description
+
+    @property
+    def script_name(self):
+        return self._script_name
+
+    # Options Parsing Workflow
+    def parse_options(self):
+        ''' General Options parsing workflow
+        '''
+
+        global_options_parser = ArgumentParser(add_help=False)
+        self.parse_global_options(global_options_parser)
+        namespace, _ = global_options_parser.parse_known_args()    
+        if namespace.cfg_dir:
+            config_handler(CustomConfig(namespace.cfg_dir))
+        else:
+            config_handler()
+
+        commands_parser = ArgumentParser(prog = self._script_name,
+                                description = 'Prometheus Exporter for Mikrotik RouterOS',
+                                formatter_class=RouterOSExporterHelpFormatter, parents=[global_options_parser])
+        self.parse_commands(commands_parser)
+        args = vars(commands_parser.parse_args())
+
+        self._check_args(args, commands_parser)
+
+        return args
+
+    def parse_global_options(self, parser):
+        ''' Parses global options
+        '''
+        parser.add_argument('--cfg-dir', dest = 'cfg_dir', 
+                    type = lambda d: self._is_valid_dir_path(parser, d),
+                    help = 'RouterOS_Exporter config files directory (optional)')
+
+    def parse_commands(self, parser):
+        ''' Commands parsing
+        '''
+        subparsers = parser.add_subparsers(dest = 'sub_cmd',
+                                           title = 'RouterOS_Exporter commands',
+                                           metavar = RouterOSExporterCommands.commands_meta())
+        
+        # Info command
+        subparsers.add_parser(RouterOSExporterCommands.INFO,
+                                        description = 'Displays RouterOS_Exporter info',
+                                        formatter_class=RouterOSExporterHelpFormatter)
+        # Show command
+        show_parser = subparsers.add_parser(RouterOSExporterCommands.SHOW,
+                                        description = 'Displays RouterOS_Exporter config router entries',
+                                        formatter_class=RouterOSExporterHelpFormatter)
+        self._add_entry_name(show_parser, registered_only = True, required = False, help = "Config entry name")
+        show_parser.add_argument('-cfg', '--config', dest='config',
+                                        help = "Shows RouterOS_Exporter config files paths",
+                                        action = 'store_true')
+
+        # Edit command
+        edit_parser = subparsers.add_parser(RouterOSExporterCommands.EDIT,
+                                        description = 'Edits an existing RouterOS_Exporter router entry',
+                                        formatter_class=RouterOSExporterHelpFormatter)
+        optional_args_group = edit_parser.add_argument_group('Optional Arguments')
+        optional_args_group.add_argument('-ed', '--editor', dest='editor',
+                help = f"Command line editor to use ({self._system_editor()} by default)",
+                default = self._system_editor(),
+                type = str)        
+        optional_args_group.add_argument('-i', '--internal', dest='internal',
+                help = f"Edit RouterOS_Exporter internal configuration (advanced)",
+                action = 'store_true')        
+
+        # Export command
+        export_parser = subparsers.add_parser(RouterOSExporterCommands.EXPORT,
+                                        description = 'Starts exporting Miktorik Router Metrics to Prometheus',
+                                        formatter_class=RouterOSExporterHelpFormatter)
+
+        # Print command
+        print_parser = subparsers.add_parser(RouterOSExporterCommands.PRINT,
+                                        description = 'Displays selected metrics on the command line',
+                                        formatter_class=RouterOSExporterHelpFormatter)
+        required_args_group = print_parser.add_argument_group('Required Arguments')
+        self._add_entry_name(required_args_group, registered_only = True, help = "Name of config RouterOS entry")
+
+        optional_args_group = print_parser.add_argument_group('Optional Arguments')
+        optional_args_group.add_argument('-cc', '--capsman_clients', dest='capsman_clients',
+                help = "CAPsMAN clients metrics",
+                action = 'store_true')
+
+        optional_args_group.add_argument('-wc', '--wifi_clients', dest='wifi_clients',
+                help = "WiFi clients metrics",
+                action = 'store_true')
+
+        optional_args_group.add_argument('-dc', '--dhcp_clients', dest='dhcp_clients',
+                help = "DHCP clients metrics",
+                action = 'store_true')
+
+        optional_args_group.add_argument('-cn', '--conn_stats', dest='conn_stats',
+                help = "IP connections stats",
+                action = 'store_true')
+
+        optional_args_group.add_argument('-kc', '--kid_control', dest='kid_control',
+                help = "Kid Control device metrics",
+                action = 'store_true')
+
+        optional_args_group.add_argument('-al', '--address_lists', dest='address_lists',
+                help = "Address List metrics (comma-separated list names)",
+                type = str,
+                metavar = 'LISTS')
+
+        optional_args_group.add_argument('-nw', '--netwatch', dest='netwatch',
+                help = "Netwatch metrics",
+                action = 'store_true')
+
+        # Entry command
+        entry_parser = subparsers.add_parser(RouterOSExporterCommands.ENTRY,
+                                        description = 'Creates a new RouterOS_Exporter router entry in the configuration file',
+                                        formatter_class=RouterOSExporterHelpFormatter)
+        required_args_group = entry_parser.add_argument_group('Required Arguments')
+        required_args_group.add_argument('-n', '--name', dest='entry_name',
+                help = "Name for the new router entry",
+                type = str,
+                required = True)
+
+        optional_args_group = entry_parser.add_argument_group('Optional Arguments')
+        optional_args_group.add_argument('-hn', '--hostname', dest='hostname',
+                help = "RouterOS device hostname or IP address",
+                type = str,
+                default = None)
+        optional_args_group.add_argument('-p', '--port', dest='port',
+                help = "RouterOS API port (default: 8728)",
+                type = int,
+                default = None)
+        optional_args_group.add_argument('-u', '--username', dest='username',
+                help = "RouterOS API username",
+                type = str,
+                default = None)
+        optional_args_group.add_argument('-pw', '--password', dest='password',
+                help = "RouterOS API password",
+                type = str,
+                default = None)
+
+
+    # Options checking
+    def _check_args(self, args, parser):
+        ''' Validation of supplied CLI arguments
+        '''
+        # check if there is a cmd to execute
+        self._check_cmd_args(args, parser)
+
+        if args['sub_cmd'] in (RouterOSExporterCommands.SHOW, RouterOSExporterCommands.PRINT):
+            # Registered Entry name could be a partial match, need to expand
+            if args['entry_name']:
+                args['entry_name'] = UniquePartialMatchList(config_handler.registered_entries()).find(args['entry_name'])
+
+        if args['sub_cmd'] == RouterOSExporterCommands.PRINT:
+            if not config_handler.config_entry(args['entry_name']).enabled:
+                print(f"Can not print metrics for disabled RouterOS entry: {args['entry_name']}\nRun 'routeros_exporter edit' to review and enable it in the configuration file first")
+                parser.exit()
+
+    def _check_cmd_args(self, args, parser):
+        ''' Validation of supplied CLI commands
+        '''
+        # base command check
+        if 'sub_cmd' not in args or not args['sub_cmd']:
+            # If no command was specified, check for the default one
+            cmd = self._default_command
+            if cmd:
+                args['sub_cmd'] = cmd
+            else:
+                # no appropriate default either
+                parser.print_help()
+                parser.exit()
+
+
+    @property
+    def _default_command(self):
+        ''' If no command was specified, print INFO by default
+        '''
+        return RouterOSExporterCommands.INFO
+
+
+    # Internal helpers
+    @staticmethod
+    def _is_valid_dir_path(parser, path_arg):
+        ''' Checks if path_arg is a valid dir path
+        '''
+        path_arg = FSHelper.full_path(path_arg)
+        if not (os.path.exists(path_arg) and os.path.isdir(path_arg)):
+            parser.error(f'"{path_arg}" does not seem to be an existing directory path')
+        else:
+            return path_arg
+
+    @staticmethod
+    def _is_valid_file_path(parser, path_arg):
+        ''' Checks if path_arg is a valid file path
+        '''
+        path_arg = FSHelper.full_path(path_arg)
+        if not (os.path.exists(path_arg) and os.path.isfile(path_arg)):
+            parser.error('"{path_arg}" does not seem to be an existing file path')
+        else:
+            return path_arg
+
+    @staticmethod
+    def _add_entry_name(parser, registered_only = False, required = True, help = 'RouterOS_Exporter Entry name'):
+        parser.add_argument('-en', '--entry-name', dest = 'entry_name',
+            type = str,
+            metavar = list(config_handler.registered_entries()) if registered_only else None,
+            required = required,
+            choices = UniquePartialMatchList(config_handler.registered_entries())if registered_only else None,
+            help = help)
+
+    @staticmethod
+    def _add_entry_groups(parser):
+        required_args_group = parser.add_argument_group('Required Arguments')
+        RouterOSExporterOptionsParser._add_entry_name(required_args_group)
+
+    @staticmethod
+    def _system_editor():
+        editor = os.environ.get('EDITOR')
+        if editor:
+            return editor
+
+        commands = ['which nano', 'which vi', 'which vim']
+        for command in commands:
+            editor = run_cmd(command, quiet = True).rstrip()
+            if editor:
+                break               
+        return editor
+
+
+class RouterOSExporterHelpFormatter(HelpFormatter):
+    ''' Custom formatter for ArgumentParser
+        Disables double metavar display, showing only for long-named options
+    '''
+    def _format_action_invocation(self, action):
+        if not action.option_strings:
+            metavar, = self._metavar_formatter(action, action.dest)(1)
+            return metavar
+        else:
+            parts = []
+            # if the Optional doesn't take a value, format is:
+            #    -s, --long
+            if action.nargs == 0:
+                parts.extend(action.option_strings)
+
+            # if the Optional takes a value, format is:
+            #    -s ARGS, --long ARGS
+            # change to
+            #    -s, --long ARGS
+            else:
+                default = action.dest.upper()
+                args_string = self._format_args(action, default)
+                for option_string in action.option_strings:
+                    #parts.append('%s %s' % (option_string, args_string))
+                    parts.append('%s' % option_string)
+                parts[-1] += ' %s'%args_string
+            return ', '.join(parts)
+

--- a/tests/cli/config/test_config.py
+++ b/tests/cli/config/test_config.py
@@ -13,146 +13,146 @@
 
 import pytest
 from configobj import ConfigObj
-from mktxp.cli.config.config import MKTXPConfigHandler, MKTXPConfigKeys, CustomConfig
-from mktxp.datasource.base_ds import BaseDSProcessor
+from routeros_exporter.cli.config.config import RouterOSExporterConfigHandler, RouterOSExporterConfigKeys, CustomConfig
+from routeros_exporter.datasource.base_ds import BaseDSProcessor
 
 def test_default_config_no_new_keys(tmpdir):
-    mktxp_conf_path = tmpdir.join("mktxp.conf")
-    _mktxp_conf_path = tmpdir.join("_mktxp.conf")
+    routeros_exporter_conf_path = tmpdir.join("routeros_exporter.conf")
+    _routeros_exporter_conf_path = tmpdir.join("exporter.conf")
 
-    config = ConfigObj(str(mktxp_conf_path))
+    config = ConfigObj(str(routeros_exporter_conf_path))
     config['default'] = {}
-    for key in MKTXPConfigKeys.BOOLEAN_KEYS_YES.union(MKTXPConfigKeys.BOOLEAN_KEYS_NO):
+    for key in RouterOSExporterConfigKeys.BOOLEAN_KEYS_YES.union(RouterOSExporterConfigKeys.BOOLEAN_KEYS_NO):
         config['default'][key] = 'False'
-    for key in MKTXPConfigKeys.STR_KEYS:
+    for key in RouterOSExporterConfigKeys.STR_KEYS:
         config['default'][key] = "some_value"
-    config['default'][MKTXPConfigKeys.PORT_KEY] = '1234'
+    config['default'][RouterOSExporterConfigKeys.PORT_KEY] = '1234'
     config.write()
 
-    _mktxp_conf_path.write("""
-[MKTXP]
+    _routeros_exporter_conf_path.write("""
+[RouterOS_Exporter]
 verbose_mode = False
 """)
 
-    handler = MKTXPConfigHandler()
+    handler = RouterOSExporterConfigHandler()
     handler(os_config=CustomConfig(str(tmpdir)))
 
-    final_config = ConfigObj(str(mktxp_conf_path))
-    assert MKTXPConfigKeys.MKTXP_LATEST_DEFAULT_ENTRY_KEY not in final_config
+    final_config = ConfigObj(str(routeros_exporter_conf_path))
+    assert RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY not in final_config
 
 def test_default_config_with_new_key(tmpdir):
-    mktxp_conf_path = tmpdir.join("mktxp.conf")
-    _mktxp_conf_path = tmpdir.join("_mktxp.conf")
-    mktxp_conf_path.write("""
+    routeros_exporter_conf_path = tmpdir.join("routeros_exporter.conf")
+    _routeros_exporter_conf_path = tmpdir.join("exporter.conf")
+    routeros_exporter_conf_path.write("""
 [default]
 # health key is missing
 """)
-    _mktxp_conf_path.write("""
-[MKTXP]
+    _routeros_exporter_conf_path.write("""
+[RouterOS_Exporter]
 verbose_mode = False
 """)
 
-    handler = MKTXPConfigHandler()
+    handler = RouterOSExporterConfigHandler()
     handler(os_config=CustomConfig(str(tmpdir)))
 
-    final_config = ConfigObj(str(mktxp_conf_path))
-    assert MKTXPConfigKeys.MKTXP_LATEST_DEFAULT_ENTRY_KEY in final_config
-    assert 'health' in final_config[MKTXPConfigKeys.MKTXP_LATEST_DEFAULT_ENTRY_KEY]
-    assert final_config[MKTXPConfigKeys.MKTXP_LATEST_DEFAULT_ENTRY_KEY].as_bool('health') is True
+    final_config = ConfigObj(str(routeros_exporter_conf_path))
+    assert RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY in final_config
+    assert 'health' in final_config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY]
+    assert final_config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY].as_bool('health') is True
     assert 'health' not in final_config['default']
 
 def test_default_config_key_in_new_section(tmpdir):
-    mktxp_conf_path = tmpdir.join("mktxp.conf")
-    _mktxp_conf_path = tmpdir.join("_mktxp.conf")
+    routeros_exporter_conf_path = tmpdir.join("routeros_exporter.conf")
+    _routeros_exporter_conf_path = tmpdir.join("exporter.conf")
 
     config = ConfigObj()
-    config.filename = str(mktxp_conf_path)
+    config.filename = str(routeros_exporter_conf_path)
     config['default'] = {}
-    for key in MKTXPConfigKeys.BOOLEAN_KEYS_YES.union(MKTXPConfigKeys.BOOLEAN_KEYS_NO):
+    for key in RouterOSExporterConfigKeys.BOOLEAN_KEYS_YES.union(RouterOSExporterConfigKeys.BOOLEAN_KEYS_NO):
         if key != 'health':
             config['default'][key] = 'False'
-    for key in MKTXPConfigKeys.STR_KEYS:
+    for key in RouterOSExporterConfigKeys.STR_KEYS:
         config['default'][key] = "some_value"
-    config['default'][MKTXPConfigKeys.PORT_KEY] = '1234'
+    config['default'][RouterOSExporterConfigKeys.PORT_KEY] = '1234'
     
-    config[MKTXPConfigKeys.MKTXP_LATEST_DEFAULT_ENTRY_KEY] = {
+    config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY] = {
         'health': 'True'
     }
     config.write()
 
-    _mktxp_conf_path.write("""
-[MKTXP]
+    _routeros_exporter_conf_path.write("""
+[RouterOS_Exporter]
 verbose_mode = False
 """)
 
-    handler = MKTXPConfigHandler()
+    handler = RouterOSExporterConfigHandler()
     handler(os_config=CustomConfig(str(tmpdir)))
 
-    final_config = ConfigObj(str(mktxp_conf_path))
-    assert 'health' in final_config[MKTXPConfigKeys.MKTXP_LATEST_DEFAULT_ENTRY_KEY]
-    assert final_config[MKTXPConfigKeys.MKTXP_LATEST_DEFAULT_ENTRY_KEY].as_bool('health') is True
+    final_config = ConfigObj(str(routeros_exporter_conf_path))
+    assert 'health' in final_config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY]
+    assert final_config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_DEFAULT_ENTRY_KEY].as_bool('health') is True
 
 def test_system_config_no_new_keys(tmpdir):
-    mktxp_conf_path = tmpdir.join("mktxp.conf")
-    _mktxp_conf_path = tmpdir.join("_mktxp.conf")
-    mktxp_conf_path.write("[default]")
+    routeros_exporter_conf_path = tmpdir.join("routeros_exporter.conf")
+    _routeros_exporter_conf_path = tmpdir.join("exporter.conf")
+    routeros_exporter_conf_path.write("[default]")
 
-    config = ConfigObj(str(_mktxp_conf_path))
-    config['MKTXP'] = {}
-    for key in MKTXPConfigKeys.MKTXP_INT_KEYS:
-        config['MKTXP'][key] = '123'
-    for key in MKTXPConfigKeys.SYSTEM_BOOLEAN_KEYS_YES.union(MKTXPConfigKeys.SYSTEM_BOOLEAN_KEYS_NO):
-        config['MKTXP'][key] = 'False'
-    config['MKTXP'][MKTXPConfigKeys.LISTEN_KEY] = "0.0.0.0:1234"
+    config = ConfigObj(str(_routeros_exporter_conf_path))
+    config['RouterOS_Exporter'] = {}
+    for key in RouterOSExporterConfigKeys.RouterOS_Exporter_INT_KEYS:
+        config['RouterOS_Exporter'][key] = '123'
+    for key in RouterOSExporterConfigKeys.SYSTEM_BOOLEAN_KEYS_YES.union(RouterOSExporterConfigKeys.SYSTEM_BOOLEAN_KEYS_NO):
+        config['RouterOS_Exporter'][key] = 'False'
+    config['RouterOS_Exporter'][RouterOSExporterConfigKeys.LISTEN_KEY] = "0.0.0.0:1234"
     config.write()
 
-    handler = MKTXPConfigHandler()
+    handler = RouterOSExporterConfigHandler()
     handler(os_config=CustomConfig(str(tmpdir)))
 
-    final_config = ConfigObj(str(_mktxp_conf_path))
-    assert MKTXPConfigKeys.MKTXP_LATEST_SYSTEM_ENTRY_KEY not in final_config
+    final_config = ConfigObj(str(_routeros_exporter_conf_path))
+    assert RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY not in final_config
 
 def test_system_config_with_new_key(tmpdir):
-    mktxp_conf_path = tmpdir.join("mktxp.conf")
-    _mktxp_conf_path = tmpdir.join("_mktxp.conf")
-    mktxp_conf_path.write("[default]")
-    _mktxp_conf_path.write("""
-[MKTXP]
+    routeros_exporter_conf_path = tmpdir.join("routeros_exporter.conf")
+    _routeros_exporter_conf_path = tmpdir.join("exporter.conf")
+    routeros_exporter_conf_path.write("[default]")
+    _routeros_exporter_conf_path.write("""
+[RouterOS_Exporter]
 # verbose_mode is missing
 """)
 
-    handler = MKTXPConfigHandler()
+    handler = RouterOSExporterConfigHandler()
     handler(os_config=CustomConfig(str(tmpdir)))
 
-    final_config = ConfigObj(str(_mktxp_conf_path))
-    assert MKTXPConfigKeys.MKTXP_LATEST_SYSTEM_ENTRY_KEY in final_config
-    assert 'verbose_mode' in final_config[MKTXPConfigKeys.MKTXP_LATEST_SYSTEM_ENTRY_KEY]
-    assert final_config[MKTXPConfigKeys.MKTXP_LATEST_SYSTEM_ENTRY_KEY].as_bool('verbose_mode') is False
-    assert 'verbose_mode' not in final_config['MKTXP']
+    final_config = ConfigObj(str(_routeros_exporter_conf_path))
+    assert RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY in final_config
+    assert 'verbose_mode' in final_config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY]
+    assert final_config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY].as_bool('verbose_mode') is False
+    assert 'verbose_mode' not in final_config['RouterOS_Exporter']
 
 def test_system_config_key_in_new_section(tmpdir):
-    mktxp_conf_path = tmpdir.join("mktxp.conf")
-    _mktxp_conf_path = tmpdir.join("_mktxp.conf")
-    mktxp_conf_path.write("[default]")
+    routeros_exporter_conf_path = tmpdir.join("routeros_exporter.conf")
+    _routeros_exporter_conf_path = tmpdir.join("exporter.conf")
+    routeros_exporter_conf_path.write("[default]")
 
-    config = ConfigObj(str(_mktxp_conf_path))
-    config['MKTXP'] = {}
-    for key in MKTXPConfigKeys.MKTXP_INT_KEYS:
-        config['MKTXP'][key] = '123'
-    for key in MKTXPConfigKeys.SYSTEM_BOOLEAN_KEYS_YES.union(MKTXPConfigKeys.SYSTEM_BOOLEAN_KEYS_NO):
+    config = ConfigObj(str(_routeros_exporter_conf_path))
+    config['RouterOS_Exporter'] = {}
+    for key in RouterOSExporterConfigKeys.RouterOS_Exporter_INT_KEYS:
+        config['RouterOS_Exporter'][key] = '123'
+    for key in RouterOSExporterConfigKeys.SYSTEM_BOOLEAN_KEYS_YES.union(RouterOSExporterConfigKeys.SYSTEM_BOOLEAN_KEYS_NO):
         if key != 'verbose_mode':
-            config['MKTXP'][key] = 'False'
-    config['MKTXP'][MKTXPConfigKeys.LISTEN_KEY] = "0.0.0.0:1234"
+            config['RouterOS_Exporter'][key] = 'False'
+    config['RouterOS_Exporter'][RouterOSExporterConfigKeys.LISTEN_KEY] = "0.0.0.0:1234"
 
-    config[MKTXPConfigKeys.MKTXP_LATEST_SYSTEM_ENTRY_KEY] = {
+    config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY] = {
         'verbose_mode': 'False'
     }
     config.write()
 
-    handler = MKTXPConfigHandler()
+    handler = RouterOSExporterConfigHandler()
     handler(os_config=CustomConfig(str(tmpdir)))
 
-    final_config = ConfigObj(str(_mktxp_conf_path))
-    assert 'verbose_mode' in final_config[MKTXPConfigKeys.MKTXP_LATEST_SYSTEM_ENTRY_KEY]
-    assert final_config[MKTXPConfigKeys.MKTXP_LATEST_SYSTEM_ENTRY_KEY].as_bool('verbose_mode') is False
+    final_config = ConfigObj(str(_routeros_exporter_conf_path))
+    assert 'verbose_mode' in final_config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY]
+    assert final_config[RouterOSExporterConfigKeys.RouterOS_Exporter_LATEST_SYSTEM_ENTRY_KEY].as_bool('verbose_mode') is False
 

--- a/tests/cli/test_entry_command.py
+++ b/tests/cli/test_entry_command.py
@@ -1,0 +1,120 @@
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from routeros_exporter.cli.dispatch import RouterOSExporterDispatcher
+
+
+class TestEntryCommand:
+    """测试 entry 命令的功能"""
+    
+    @patch('routeros_exporter.cli.dispatch.config_handler')
+    @patch('builtins.print')
+    def test_create_new_entry_success(self, mock_print, mock_config_handler):
+        """测试成功创建新的配置条目"""
+        # 设置 mock
+        mock_config_handler.registered_entry.return_value = None
+        mock_config = MagicMock()
+        mock_config.comments = {}
+        mock_config_handler.config = mock_config
+        mock_config_handler.usr_conf_data_path = '/test/path/routeros_exporter.conf'
+
+        # 创建 dispatcher
+        dispatcher = RouterOSExporterDispatcher()
+
+        # 准备参数
+        args = {
+            'entry_name': 'TestRouter',
+            'hostname': '192.168.1.1',
+            'port': 8728,
+            'username': 'admin',
+            'password': 'test123'
+        }
+
+        # 执行创建
+        dispatcher.create_entry(args)
+
+        # 验证配置已创建 - 检查 __setitem__ 调用
+        mock_config.__setitem__.assert_called()
+        # 验证成功消息
+        mock_print.assert_any_call('成功创建配置条目 [TestRouter]')
+        # 验证 write 方法被调用
+        mock_config.write.assert_called_once()
+    
+    @patch('routeros_exporter.cli.dispatch.config_handler')
+    @patch('builtins.print')
+    def test_create_entry_already_exists(self, mock_print, mock_config_handler):
+        """测试创建已存在的配置条目时的错误处理"""
+        # 设置 mock - 条目已存在
+        mock_config_handler.registered_entry.return_value = {'hostname': '192.168.1.1'}
+        
+        # 创建 dispatcher
+        dispatcher = RouterOSExporterDispatcher()
+        
+        # 准备参数
+        args = {
+            'entry_name': 'ExistingRouter',
+            'hostname': '192.168.1.2'
+        }
+        
+        # 执行创建
+        dispatcher.create_entry(args)
+        
+        # 验证错误消息
+        mock_print.assert_any_call('错误: 配置条目 [ExistingRouter] 已存在')
+        mock_print.assert_any_call('使用 "routeros_exporter edit" 命令编辑现有条目')
+    
+    @patch('routeros_exporter.cli.dispatch.config_handler')
+    @patch('builtins.print')
+    def test_create_entry_minimal_params(self, mock_print, mock_config_handler):
+        """测试只使用必需参数创建配置条目"""
+        # 设置 mock
+        mock_config_handler.registered_entry.return_value = None
+        mock_config = MagicMock()
+        mock_config.comments = {}
+        mock_config_handler.config = mock_config
+        mock_config_handler.usr_conf_data_path = '/test/path/routeros_exporter.conf'
+
+        # 创建 dispatcher
+        dispatcher = RouterOSExporterDispatcher()
+
+        # 准备参数 - 只有名称
+        args = {
+            'entry_name': 'MinimalRouter'
+        }
+
+        # 执行创建
+        dispatcher.create_entry(args)
+
+        # 验证配置已创建
+        mock_config.__setitem__.assert_called()
+        # 验证成功消息
+        mock_print.assert_any_call('成功创建配置条目 [MinimalRouter]')
+        # 验证 write 方法被调用
+        mock_config.write.assert_called_once()
+    
+    @patch('routeros_exporter.cli.dispatch.config_handler')
+    def test_create_entry_with_comments(self, mock_config_handler):
+        """测试创建配置条目时添加注释"""
+        # 设置 mock
+        mock_config_handler.registered_entry.return_value = None
+        mock_config = MagicMock()
+        mock_config.comments = {}
+        mock_config_handler.config = mock_config
+        mock_config_handler.usr_conf_data_path = '/test/path/routeros_exporter.conf'
+
+        # 创建 dispatcher
+        dispatcher = RouterOSExporterDispatcher()
+
+        # 准备参数
+        args = {
+            'entry_name': 'CommentedRouter',
+            'hostname': '192.168.1.1'
+        }
+
+        # 执行创建
+        dispatcher.create_entry(args)
+
+        # 验证注释已添加
+        assert 'CommentedRouter' in mock_config.comments
+        comments = mock_config.comments['CommentedRouter']
+        assert any('RouterOS device configuration' in comment for comment in comments)
+


### PR DESCRIPTION
主要变更:
- 添加 'entry' 命令用于快速创建路由器配置条目
- 优化配置文件路径和命名:
  * Linux/Docker: /app/device.conf (设备配置) + /app/exporter.conf (系统配置)
  * macOS/FreeBSD: ~/routeros_exporter/routeros_exporter.conf + ~/routeros_exporter/exporter.conf
- 重命名系统配置文件: _routeros_exporter.conf -> exporter.conf
- Linux 环境设备配置文件: default.conf -> device.conf

新功能:
- routeros_exporter entry 命令支持创建新的路由器配置条目
- 支持参数: -n (名称), -hn (主机名), -p (端口), -u (用户名), -pw (密码)
- 自动检测重复条目并提供友好提示
- 自动添加配置注释

测试:
- 新增 tests/cli/test_entry_command.py (4个测试用例)
- 更新 tests/cli/config/test_config.py 以适配新的配置文件名
- 所有测试通过 (167个测试)

文档:
- 更新 README.md 说明新的配置文件路径和 entry 命令用法
- 添加 Docker 和本地安装的配置文件路径对比表