### PR TITLE
fix: resolve OCI runtime error in mktxp container

### DIFF
--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       containers:
       - name: mktxp-exporter
         image: ghcr.io/akpw/mktxp:latest
+        command: ["mktxp"]
         args:
           - --cfg-dir
           - /mktxp_config


### PR DESCRIPTION
### Summary
This PR fixes a critical container startup error in the mktxp exporter deployment by adding an explicit `command` to the container specification.

### Problem
The mktxp exporter pods were failing to start with the following error:

```error
Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "--cfg-dir": executable file not found in $PATH
```

**Root Cause:** The current version deployment (1.2.16) configuration does not specify an entrypoint command for the container. Kubernetes therefore attempts to execute the first argument (`--cfg-dir`) as if it were a command, which results in the "executable file not found" error.

### Solution
Added `command: ["mktxp"]` to the container spec. This explicitly defines the entrypoint executable, allowing the subsequent `args` to be passed correctly.

### Changes Made
- **File:** `deployment.yaml`
- **Change:** Added the line `command: ["mktxp"]` to the `mktxp-exporter` container definition.