### PR TITLE
feat: Add configurable `http_server_threads`

### DIFF
--- a/mktxp/cli/config/_mktxp.conf
+++ b/mktxp/cli/config/_mktxp.conf
@@ -30,6 +30,7 @@
     max_worker_threads = 5              # Max number of worker threads that can fetch routers (parallel fetch only)
     max_scrape_duration = 30            # Max duration of individual routers' metrics collection (parallel fetch only)
     total_max_scrape_duration = 90      # Max overall duration of all metrics collection (parallel fetch only)
+    http_server_threads = 16            # Number of worker threads for the HTTP server
 
     persistent_router_connection_pool = True  # Use a persistent router connections pool between scrapes
     persistent_dhcp_cache = True              # Persist DHCP cache between metric collections

--- a/mktxp/cli/config/config.py
+++ b/mktxp/cli/config/config.py
@@ -157,6 +157,7 @@ class MKTXPConfigKeys:
     MKTXP_PERSISTENT_ROUTER_CONNECTION_POOL = 'persistent_router_connection_pool'
     MKTXP_PERSISTENT_DHCP_CACHE = 'persistent_dhcp_cache'
     MKTXP_BANDWIDTH_TEST_DNS_SERVER = 'bandwidth_test_dns_server'
+    MKTXP_HTTP_SERVER_THREADS = 'http_server_threads'
     MKTXP_PROBE_CONNECTION_POOL = 'probe_connection_pool'
     MKTXP_PROBE_CONNECTION_POOL_TTL = 'probe_connection_pool_ttl'
     MKTXP_PROBE_CONNECTION_POOL_MAX_SIZE = 'probe_connection_pool_max_size'
@@ -202,6 +203,7 @@ class MKTXPConfigKeys:
     DEFAULT_MKTXP_MAX_SCRAPE_DURATION = 10
     DEFAULT_MKTXP_TOTAL_MAX_SCRAPE_DURATION = 30
     DEFAULT_MKTXP_BANDWIDTH_TEST_DNS_SERVER = "8.8.8.8"
+    DEFAULT_MKTXP_HTTP_SERVER_THREADS = 16
     DEFAULT_MKTXP_PROBE_CONNECTION_POOL_TTL = 300
     DEFAULT_MKTXP_PROBE_CONNECTION_POOL_MAX_SIZE = 128
 
@@ -226,7 +228,8 @@ class MKTXPConfigKeys:
     MKTXP_INT_KEYS = (PORT_KEY, MKTXP_SOCKET_TIMEOUT, MKTXP_INITIAL_DELAY, MKTXP_MAX_DELAY,
                       MKTXP_INC_DIV, MKTXP_BANDWIDTH_TEST_INTERVAL, MKTXP_MIN_COLLECT_INTERVAL,
                       MKTXP_MAX_WORKER_THREADS, MKTXP_MAX_SCRAPE_DURATION, MKTXP_TOTAL_MAX_SCRAPE_DURATION,
-                      MKTXP_PROBE_CONNECTION_POOL_TTL, MKTXP_PROBE_CONNECTION_POOL_MAX_SIZE)
+                      MKTXP_PROBE_CONNECTION_POOL_TTL, MKTXP_PROBE_CONNECTION_POOL_MAX_SIZE,
+                      MKTXP_HTTP_SERVER_THREADS)
 
     # MKTXP configs entry names
     DEFAULT_ENTRY_KEY = 'default'
@@ -260,7 +263,8 @@ class ConfigEntry:
                                                        MKTXPConfigKeys.MKTXP_PROMETHEUS_HEADERS_DEDUPLICATION, MKTXPConfigKeys.MKTXP_PERSISTENT_ROUTER_CONNECTION_POOL,
                                                        MKTXPConfigKeys.MKTXP_PERSISTENT_DHCP_CACHE, MKTXPConfigKeys.MKTXP_BANDWIDTH_TEST_DNS_SERVER,
                                                        MKTXPConfigKeys.MKTXP_PROBE_CONNECTION_POOL, MKTXPConfigKeys.MKTXP_PROBE_CONNECTION_POOL_TTL,
-                                                       MKTXPConfigKeys.MKTXP_PROBE_CONNECTION_POOL_MAX_SIZE])
+                                                       MKTXPConfigKeys.MKTXP_PROBE_CONNECTION_POOL_MAX_SIZE,
+                                                       MKTXPConfigKeys.MKTXP_HTTP_SERVER_THREADS])
 
 
 class OSConfig(metaclass=ABCMeta):
@@ -343,7 +347,8 @@ mockSystemEntry = ConfigEntry.MKTXPSystemEntry(
             bandwidth_test_dns_server=MKTXPConfigKeys.DEFAULT_MKTXP_BANDWIDTH_TEST_DNS_SERVER,
             probe_connection_pool=False,
             probe_connection_pool_ttl=MKTXPConfigKeys.DEFAULT_MKTXP_PROBE_CONNECTION_POOL_TTL,
-            probe_connection_pool_max_size=MKTXPConfigKeys.DEFAULT_MKTXP_PROBE_CONNECTION_POOL_MAX_SIZE
+            probe_connection_pool_max_size=MKTXPConfigKeys.DEFAULT_MKTXP_PROBE_CONNECTION_POOL_MAX_SIZE,
+            http_server_threads=MKTXPConfigKeys.DEFAULT_MKTXP_HTTP_SERVER_THREADS
         )
 
 class MKTXPConfigHandler:
@@ -674,6 +679,7 @@ class MKTXPConfigHandler:
             MKTXPConfigKeys.MKTXP_BANDWIDTH_TEST_DNS_SERVER: lambda _: MKTXPConfigKeys.DEFAULT_MKTXP_BANDWIDTH_TEST_DNS_SERVER,
             MKTXPConfigKeys.MKTXP_PROBE_CONNECTION_POOL_TTL: lambda _: MKTXPConfigKeys.DEFAULT_MKTXP_PROBE_CONNECTION_POOL_TTL,
             MKTXPConfigKeys.MKTXP_PROBE_CONNECTION_POOL_MAX_SIZE: lambda _: MKTXPConfigKeys.DEFAULT_MKTXP_PROBE_CONNECTION_POOL_MAX_SIZE,
+            MKTXPConfigKeys.MKTXP_HTTP_SERVER_THREADS: lambda _: MKTXPConfigKeys.DEFAULT_MKTXP_HTTP_SERVER_THREADS,
         }[key](value)
 
 

--- a/mktxp/flow/processor/base_proc.py
+++ b/mktxp/flow/processor/base_proc.py
@@ -106,9 +106,17 @@ class ExportProcessor:
             if config_handler.system_entry.verbose_mode:
                 print(f"Prometheus HELP / TYPE headers de-deplucation is On")
             middleware = PrometheusHeadersDeduplicatingMiddleware(app)
-            serve(middleware, listen = config_handler.system_entry.listen)
+            serve(
+                middleware,
+                listen = config_handler.system_entry.listen,
+                threads = config_handler.system_entry.http_server_threads
+            )
         else:
-            serve(app, listen = config_handler.system_entry.listen)
+            serve(
+                app,
+                listen = config_handler.system_entry.listen,
+                threads = config_handler.system_entry.http_server_threads
+            )
 
 
 class MetricsRouter:


### PR DESCRIPTION
- Adds a new system config key `http_server_threads` (default 16) and wires it into Waitress `serve()` calls.
- Updates config parsing/defaults and `_mktxp.conf` template to expose the new setting.

Problem Solved:
- Prevents Waitress queue depth warnings and request backlogs under high scrape concurrency by allowing the HTTP server thread count to be tuned to workload.

Issue disussed briefly in #291 