### PR TITLE
Export wireless client uptime/rates as gauges instead of info labels

### DIFF
--- a/docs/exporter.md
+++ b/docs/exporter.md
@@ -11,6 +11,7 @@
   - [Minimal Router Entry](#minimal-router-entry)
   - [Canonical Template](#canonical-template)
   - [System Settings (`_mktxp.conf`)](#system-settings-_mktxpconf)
+- [Wireless Client Metrics](#wireless-client-metrics)
 - [Prometheus Scrape Configuration](#prometheus-scrape-configuration)
 - [Multi-Target Exporter Pattern (`/probe`)](#multi-target-exporter-pattern-probe)
 - [Production Daemon Deployments](#production-daemon-deployments)
@@ -84,6 +85,30 @@ Tune daemon-level parameters with `mktxp edit -i`:
 ```
 
 > 📖 *For the complete configuration reference, multi-router `[default]` inheritance, parallel scraping, and Docker deployment, see the [Configuration Guide](configuration.md).*
+
+---
+
+## Wireless Client Metrics
+
+With `wireless_clients` / `capsman_clients` enabled, every connected station is exported as one info series plus a set of per-client gauges and counters. The `wlan_` and `capsman_` families are identical in shape:
+
+| Metric | Type | Labels (in addition to `routerboard_name`, `routerboard_address`) |
+|---|---|---|
+| `mktxp_{wlan,capsman}_clients_devices_info` | info | `dhcp_name`, `dhcp_address`, `mac_address`, `ssid`, `interface`, `band` |
+| `mktxp_{wlan,capsman}_clients_uptime_seconds` | gauge | `dhcp_name`, `mac_address` |
+| `mktxp_{wlan,capsman}_clients_tx_rate_bps` | gauge | `dhcp_name`, `mac_address` |
+| `mktxp_{wlan,capsman}_clients_rx_rate_bps` | gauge | `dhcp_name`, `mac_address` |
+| `mktxp_{wlan,capsman}_clients_signal_strength` | gauge | `dhcp_name`, `mac_address` |
+| `mktxp_{wlan,capsman}_clients_tx_bytes` / `_rx_bytes` | counter | `dhcp_name`, `mac_address` |
+| `mktxp_wlan_clients_signal_to_noise`, `mktxp_wlan_clients_tx_ccq` | gauge | `dhcp_name`, `mac_address` |
+
+The info metric carries only labels that stay constant while a station is connected, so each client maps to a single time series. Values that change from scrape to scrape (uptime, negotiated rates, signal) are exported as gauges and can be joined to the info series on `mac_address`, e.g.:
+
+```promql
+mktxp_wlan_clients_tx_rate_bps * on (routerboard_name, mac_address) group_left (ssid, band) mktxp_wlan_clients_devices_info
+```
+
+Negotiated rates are parsed from the RouterOS rate string (e.g. `866.6Mbps-80MHz/2S/SGI` → `866600000`), uptime from the RouterOS duration string (e.g. `1d2h3m4s` → `93784`). A value that cannot be parsed is logged and its sample omitted; the rest of the scrape is unaffected.
 
 ---
 

--- a/mktxp/collector/capsman_collector.py
+++ b/mktxp/collector/capsman_collector.py
@@ -13,7 +13,7 @@
 
 
 from mktxp.cli.config import MKTXPConfigKeys
-from mktxp.flow.processor.enrichment import augment_record
+from mktxp.flow.processor.enrichment import augment_record, add_registration_gauges
 from mktxp.collector.base_collector import BaseCollector
 from mktxp.datasource.capsman_ds import CapsmanCapsMetricsDataSource, CapsmanRegistrationsMetricsDataSource, CapsmanInterfacesDatasource
 from mktxp.datasource.wireless_ds import WirelessMetricsDataSource
@@ -53,6 +53,7 @@ class CapsmanCollector(BaseCollector):
 
                 # translate / trim / augment registration records
                 for registration_record in registration_records:
+                    add_registration_gauges(registration_record)
                     augment_record(router_entry, registration_record)
 
                 tx_byte_metrics = BaseCollector.counter_collector('capsman_clients_tx_bytes', 'Number of sent packet bytes', registration_records, 'tx_bytes', ['dhcp_name', 'mac_address'])
@@ -64,8 +65,21 @@ class CapsmanCollector(BaseCollector):
                 signal_strength_metrics = BaseCollector.gauge_collector('capsman_clients_signal_strength', 'Client devices signal strength', registration_records, 'rx_signal', ['dhcp_name', 'mac_address'])
                 yield signal_strength_metrics
 
+                uptime_records = [record for record in registration_records if 'uptime_seconds' in record]
+                if uptime_records:
+                    yield BaseCollector.gauge_collector('capsman_clients_uptime_seconds', 'Client devices connection uptime in seconds', uptime_records, 'uptime_seconds', ['dhcp_name', 'mac_address'])
+
+                tx_rate_records = [record for record in registration_records if 'tx_rate_bps' in record]
+                if tx_rate_records:
+                    yield BaseCollector.gauge_collector('capsman_clients_tx_rate_bps', 'Client devices negotiated TX rate in bits per second', tx_rate_records, 'tx_rate_bps', ['dhcp_name', 'mac_address'])
+
+                rx_rate_records = [record for record in registration_records if 'rx_rate_bps' in record]
+                if rx_rate_records:
+                    yield BaseCollector.gauge_collector('capsman_clients_rx_rate_bps', 'Client devices negotiated RX rate in bits per second', rx_rate_records, 'rx_rate_bps', ['dhcp_name', 'mac_address'])
+
+                # only labels that stay constant for the lifetime of a registration, so a client maps to a single time series
                 registration_metrics = BaseCollector.info_collector('capsman_clients_devices', 'Registered client devices info',
-                                        registration_records, ['dhcp_name', 'dhcp_address', 'rx_signal', 'ssid', 'tx_rate', 'rx_rate', 'interface', 'mac_address', 'uptime', 'band'])
+                                        registration_records, ['dhcp_name', 'dhcp_address', 'ssid', 'interface', 'mac_address', 'band'])
                 yield registration_metrics
 
 

--- a/mktxp/collector/wlan_collector.py
+++ b/mktxp/collector/wlan_collector.py
@@ -12,7 +12,7 @@
 ## GNU General Public License for more details.
 
 
-from mktxp.flow.processor.enrichment import augment_record
+from mktxp.flow.processor.enrichment import augment_record, add_registration_gauges
 from mktxp.collector.base_collector import BaseCollector
 from mktxp.datasource.wireless_ds import WirelessMetricsDataSource
 from mktxp.datasource.interface_ds import InterfaceMonitorMetricsDataSource
@@ -52,6 +52,7 @@ class WLANCollector(BaseCollector):
             registration_records = WirelessMetricsDataSource.metric_records(router_entry, metric_labels = registration_labels)
             if registration_records:
                 for registration_record in registration_records:
+                    add_registration_gauges(registration_record)
                     augment_record(router_entry, registration_record)
 
                 tx_byte_metrics = BaseCollector.counter_collector('wlan_clients_tx_bytes', 'Number of sent packet bytes', registration_records, 'tx_bytes', ['dhcp_name', 'mac_address'])
@@ -69,8 +70,21 @@ class WLANCollector(BaseCollector):
                 tx_ccq_metrics = BaseCollector.gauge_collector('wlan_clients_tx_ccq', 'Client Connection Quality (CCQ) for transmit', registration_records, 'tx_ccq', ['dhcp_name', 'mac_address'])
                 yield tx_ccq_metrics
 
+                uptime_records = [record for record in registration_records if 'uptime_seconds' in record]
+                if uptime_records:
+                    yield BaseCollector.gauge_collector('wlan_clients_uptime_seconds', 'Client devices connection uptime in seconds', uptime_records, 'uptime_seconds', ['dhcp_name', 'mac_address'])
+
+                tx_rate_records = [record for record in registration_records if 'tx_rate_bps' in record]
+                if tx_rate_records:
+                    yield BaseCollector.gauge_collector('wlan_clients_tx_rate_bps', 'Client devices negotiated TX rate in bits per second', tx_rate_records, 'tx_rate_bps', ['dhcp_name', 'mac_address'])
+
+                rx_rate_records = [record for record in registration_records if 'rx_rate_bps' in record]
+                if rx_rate_records:
+                    yield BaseCollector.gauge_collector('wlan_clients_rx_rate_bps', 'Client devices negotiated RX rate in bits per second', rx_rate_records, 'rx_rate_bps', ['dhcp_name', 'mac_address'])
+
+                # only labels that stay constant for the lifetime of a registration, so a client maps to a single time series
                 registration_metrics = BaseCollector.info_collector('wlan_clients_devices', 'Client devices info', 
-                                        registration_records, ['dhcp_name', 'dhcp_address', 'rx_signal', 'ssid', 'tx_rate', 'rx_rate', 'interface', 'mac_address', 'uptime', 'band'])
+                                        registration_records, ['dhcp_name', 'dhcp_address', 'ssid', 'interface', 'mac_address', 'band'])
                 yield registration_metrics
 
 

--- a/mktxp/flow/processor/enrichment.py
+++ b/mktxp/flow/processor/enrichment.py
@@ -17,6 +17,8 @@ from mktxp.utils.units import (
     parse_bitrates,
     parse_timedelta_seconds,
     parse_signal_strength,
+    parse_uptime_seconds,
+    parse_rate_bps,
 )
 
 
@@ -91,6 +93,27 @@ def resolve_dhcp(
     registration_record['dhcp_name'] = name
     if resolve_address:
         registration_record['dhcp_address'] = dhcp_address
+
+
+def add_registration_gauges(registration_record):
+    """Adds numeric uptime_seconds / tx_rate_bps / rx_rate_bps keys parsed from the raw RouterOS
+    registration values. Must run before augment_record, which reformats those values for display.
+    Unparseable values are reported and skipped, so the record simply lacks that gauge."""
+    for source_key, target_key, parse in (
+        ('uptime', 'uptime_seconds', parse_uptime_seconds),
+        ('tx_rate', 'tx_rate_bps', parse_rate_bps),
+        ('rx_rate', 'rx_rate_bps', parse_rate_bps),
+    ):
+        raw_value = registration_record.get(source_key)
+        if not raw_value:
+            continue
+        value = parse(raw_value)
+        if value is None:
+            print(
+                f"Warning: could not parse {source_key} '{raw_value}' for client {registration_record.get('mac_address', '')}, skipping sample"
+            )
+            continue
+        registration_record[target_key] = value
 
 
 def augment_record(router_entry, registration_record, id_key='mac_address'):

--- a/mktxp/utils/units.py
+++ b/mktxp/utils/units.py
@@ -165,3 +165,34 @@ def parse_signal_strength(signal_strength):
     wifi_signal_strength_rgx = _get_re('wifi_signal_strength_rgx', r'(-?\d+(?:\.\d+)?)')
     match = wifi_signal_strength_rgx.search(str(signal_strength))
     return match.group() if match else ""
+
+
+def parse_uptime_seconds(uptime):
+    """Parses RouterOS uptime string (e.g. '1w2d3h4m5s', '45s') into integer seconds.
+    Unlike parse_timedelta, the whole string must be a valid duration; returns None otherwise."""
+    if uptime is None:
+        return None
+    uptime_rgx = _get_re(
+        'uptime_rgx',
+        r'^((?P<weeks>\d+)w)?((?P<days>\d+)d)?((?P<hours>\d+)h)?((?P<minutes>\d+)m)?((?P<seconds>\d+)s)?((?P<milliseconds>\d+)ms)?$',
+    )
+    matched = uptime_rgx.match(str(uptime).strip())
+    if not matched or not matched.group():
+        return None
+    return int(timedelta(**{key: int(value) for key, value in matched.groupdict().items() if value}).total_seconds())
+
+
+def parse_rate_bps(rate):
+    """Parses RouterOS wireless rate string (e.g. '866.6Mbps-80MHz/2S/SGI', '6Mbps', raw '866000000') into integer bps.
+    Returns None when the value does not start with a recognizable rate."""
+    if rate is None:
+        return None
+    rate_str = str(rate).strip()
+    if rate_str.isdigit():
+        return int(rate_str)
+    rate_bps_rgx = _get_re('rate_bps_rgx', r'(?i)^(\d+(?:\.\d+)?)\s*([kmg]?)bps')
+    matched = rate_bps_rgx.match(rate_str)
+    if not matched:
+        return None
+    multiplier = {'': 1, 'k': 1000, 'm': 1000 ** 2, 'g': 1000 ** 3}[matched.group(2).lower()]
+    return int(round(float(matched.group(1)) * multiplier))

--- a/tests/collector/test_capsman_collector.py
+++ b/tests/collector/test_capsman_collector.py
@@ -1,0 +1,75 @@
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+from unittest.mock import MagicMock, patch
+from mktxp.collector.capsman_collector import CapsmanCollector
+
+registration_records = [
+    {'interface': 'cap1', 'ssid': 'Home', 'mac_address': 'AA:BB:CC:DD:EE:01', 'tx_rate': '866.6Mbps-80MHz/2S/SGI', 'rx_rate': '144.4Mbps',
+     'rx_signal': '-61', 'uptime': '1d2h3m4s', 'bytes': '1000,2000', 'band': '5ghz-ac'},
+    {'interface': 'cap1', 'ssid': 'Home', 'mac_address': 'AA:BB:CC:DD:EE:02', 'tx_rate': 'unknown', 'rx_rate': '6Mbps',
+     'rx_signal': '-75', 'uptime': '45s', 'bytes': '10,20', 'band': '2ghz-n'},
+]
+
+VOLATILE_LABELS = {'uptime', 'rx_signal', 'tx_rate', 'rx_rate'}
+CLIENT_GAUGE_LABELS = {'dhcp_name', 'mac_address', 'routerboard_name', 'routerboard_address'}
+
+
+def _router_entry():
+    router_entry = MagicMock()
+    router_entry.dhcp_records = [{'mac_address': 'AA:BB:CC:DD:EE:01'}]
+    router_entry.dhcp_record.return_value = {'host_name': 'Device1', 'address': '10.0.0.5'}
+    router_entry.config_entry.interface_name_format = 'name'
+    return router_entry
+
+
+def _metrics_by_name(metrics):
+    return {metric.name: metric for metric in metrics}
+
+
+@patch('mktxp.collector.capsman_collector.CapsmanInterfacesDatasource.metric_records', return_value=None)
+@patch('mktxp.collector.capsman_collector.CapsmanCapsMetricsDataSource.metric_records', return_value=None)
+@patch('mktxp.collector.capsman_collector.CapsmanRegistrationsMetricsDataSource.metric_records')
+def test_capsman_client_metrics(mock_registrations, mock_caps, mock_interfaces):
+    mock_registrations.return_value = [dict(record) for record in registration_records]
+    router_entry = _router_entry()
+    router_entry.config_entry.capsman = True
+    router_entry.config_entry.capsman_clients = True
+
+    metrics = _metrics_by_name(CapsmanCollector.collect(router_entry))
+
+    assert {'mktxp_capsman_clients_uptime_seconds', 'mktxp_capsman_clients_tx_rate_bps',
+            'mktxp_capsman_clients_rx_rate_bps', 'mktxp_capsman_clients_signal_strength',
+            'mktxp_capsman_clients_devices'} <= set(metrics)
+
+    # info labels are stable identity only
+    info = metrics['mktxp_capsman_clients_devices']
+    assert len(info.samples) == 2
+    for sample in info.samples:
+        assert not VOLATILE_LABELS & set(sample.labels)
+        assert {'dhcp_name', 'dhcp_address', 'ssid', 'interface', 'mac_address', 'band'} <= set(sample.labels)
+
+    # volatile values are gauges keyed like the existing per-client gauges
+    for name in ('mktxp_capsman_clients_uptime_seconds', 'mktxp_capsman_clients_tx_rate_bps', 'mktxp_capsman_clients_rx_rate_bps'):
+        for sample in metrics[name].samples:
+            assert set(sample.labels) == CLIENT_GAUGE_LABELS
+
+    uptime = {s.labels['mac_address']: s.value for s in metrics['mktxp_capsman_clients_uptime_seconds'].samples}
+    assert uptime == {'AA:BB:CC:DD:EE:01': 93784, 'AA:BB:CC:DD:EE:02': 45}
+
+    rx_rate = {s.labels['mac_address']: s.value for s in metrics['mktxp_capsman_clients_rx_rate_bps'].samples}
+    assert rx_rate == {'AA:BB:CC:DD:EE:01': 144400000, 'AA:BB:CC:DD:EE:02': 6000000}
+
+    # the unparseable tx_rate sample is dropped, the rest of the collection is intact
+    tx_rate = {s.labels['mac_address']: s.value for s in metrics['mktxp_capsman_clients_tx_rate_bps'].samples}
+    assert tx_rate == {'AA:BB:CC:DD:EE:01': 866600000}

--- a/tests/collector/test_wlan_collector.py
+++ b/tests/collector/test_wlan_collector.py
@@ -1,0 +1,74 @@
+# coding=utf8
+## Copyright (c) 2020 Arseniy Kuznetsov
+##
+## This program is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation; either version 2
+## of the License, or (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+from unittest.mock import MagicMock, patch
+from mktxp.collector.wlan_collector import WLANCollector
+
+registration_records = [
+    {'interface': 'wlan1', 'ssid': 'Home', 'mac_address': 'AA:BB:CC:DD:EE:01', 'tx_rate': '866.6Mbps-80MHz/2S/SGI', 'rx_rate': '144.4Mbps',
+     'uptime': '3h15m2s', 'bytes': '1000,2000', 'signal_to_noise': '40', 'tx_ccq': '90', 'signal_strength': '-61dBm', 'band': '5ghz-ac'},
+    {'interface': 'wlan1', 'ssid': 'Home', 'mac_address': 'AA:BB:CC:DD:EE:02', 'tx_rate': '6Mbps', 'rx_rate': 'unknown',
+     'uptime': '45s', 'bytes': '10,20', 'signal_to_noise': '20', 'tx_ccq': '50', 'signal_strength': '-75dBm', 'band': '2ghz-n'},
+]
+
+VOLATILE_LABELS = {'uptime', 'rx_signal', 'tx_rate', 'rx_rate'}
+CLIENT_GAUGE_LABELS = {'dhcp_name', 'mac_address', 'routerboard_name', 'routerboard_address'}
+
+
+def _router_entry():
+    router_entry = MagicMock()
+    router_entry.dhcp_records = [{'mac_address': 'AA:BB:CC:DD:EE:01'}]
+    router_entry.dhcp_record.return_value = {'host_name': 'Device1', 'address': '10.0.0.5'}
+    router_entry.config_entry.interface_name_format = 'name'
+    return router_entry
+
+
+def _metrics_by_name(metrics):
+    return {metric.name: metric for metric in metrics}
+
+
+@patch('mktxp.collector.wlan_collector.InterfaceMonitorMetricsDataSource.metric_records', return_value=None)
+@patch('mktxp.collector.wlan_collector.WirelessMetricsDataSource.metric_records')
+def test_wlan_client_metrics(mock_registrations, mock_monitor):
+    mock_registrations.return_value = [dict(record) for record in registration_records]
+    router_entry = _router_entry()
+    router_entry.config_entry.wireless = True
+    router_entry.config_entry.wireless_clients = True
+
+    metrics = _metrics_by_name(WLANCollector.collect(router_entry))
+
+    assert {'mktxp_wlan_clients_uptime_seconds', 'mktxp_wlan_clients_tx_rate_bps',
+            'mktxp_wlan_clients_rx_rate_bps', 'mktxp_wlan_clients_signal_strength',
+            'mktxp_wlan_clients_devices'} <= set(metrics)
+
+    # info labels are stable identity only
+    info = metrics['mktxp_wlan_clients_devices']
+    assert len(info.samples) == 2
+    for sample in info.samples:
+        assert not VOLATILE_LABELS & set(sample.labels)
+        assert {'dhcp_name', 'dhcp_address', 'ssid', 'interface', 'mac_address', 'band'} <= set(sample.labels)
+
+    # volatile values are gauges keyed like the existing per-client gauges
+    for name in ('mktxp_wlan_clients_uptime_seconds', 'mktxp_wlan_clients_tx_rate_bps', 'mktxp_wlan_clients_rx_rate_bps'):
+        for sample in metrics[name].samples:
+            assert set(sample.labels) == CLIENT_GAUGE_LABELS
+
+    uptime = {s.labels['mac_address']: s.value for s in metrics['mktxp_wlan_clients_uptime_seconds'].samples}
+    assert uptime == {'AA:BB:CC:DD:EE:01': 11702, 'AA:BB:CC:DD:EE:02': 45}
+
+    tx_rate = {s.labels['mac_address']: s.value for s in metrics['mktxp_wlan_clients_tx_rate_bps'].samples}
+    assert tx_rate == {'AA:BB:CC:DD:EE:01': 866600000, 'AA:BB:CC:DD:EE:02': 6000000}
+
+    # the unparseable rx_rate sample is dropped, the rest of the collection is intact
+    rx_rate = {s.labels['mac_address']: s.value for s in metrics['mktxp_wlan_clients_rx_rate_bps'].samples}
+    assert rx_rate == {'AA:BB:CC:DD:EE:01': 144400000}

--- a/tests/flow/test_enrichment.py
+++ b/tests/flow/test_enrichment.py
@@ -17,6 +17,7 @@ from mktxp.flow.processor.enrichment import (
     dhcp_name,
     resolve_dhcp,
     augment_record,
+    add_registration_gauges,
 )
 
 
@@ -61,3 +62,32 @@ def test_augment_record():
     assert rec['rx_bytes'] == '2000'
     assert rec['tx_rate'] == '866 Mbps'
     assert rec['signal_strength'] == '-65'
+
+
+def test_add_registration_gauges():
+    rec = {
+        'mac_address': 'AA:BB:CC:DD:EE:FF',
+        'tx_rate': '866.6Mbps-80MHz/2S/SGI',
+        'rx_rate': '144.4Mbps',
+        'uptime': '1d2h3m4s',
+    }
+
+    add_registration_gauges(rec)
+
+    assert rec['tx_rate_bps'] == 866600000
+    assert rec['rx_rate_bps'] == 144400000
+    assert rec['uptime_seconds'] == 93784
+    # raw values are left in place for augment_record
+    assert rec['tx_rate'] == '866.6Mbps-80MHz/2S/SGI'
+    assert rec['uptime'] == '1d2h3m4s'
+
+
+def test_add_registration_gauges_skips_unparseable(capsys):
+    rec = {'mac_address': 'AA:BB:CC:DD:EE:FF', 'tx_rate': 'unknown', 'rx_rate': '6Mbps', 'uptime': ''}
+
+    add_registration_gauges(rec)
+
+    assert 'tx_rate_bps' not in rec
+    assert 'uptime_seconds' not in rec
+    assert rec['rx_rate_bps'] == 6000000
+    assert "could not parse tx_rate 'unknown'" in capsys.readouterr().out

--- a/tests/utils/test_units.py
+++ b/tests/utils/test_units.py
@@ -23,6 +23,8 @@ from mktxp.utils.units import (
     parse_timedelta_milliseconds,
     parse_duration_limit,
     parse_signal_strength,
+    parse_uptime_seconds,
+    parse_rate_bps,
 )
 
 
@@ -87,3 +89,36 @@ def test_parse_signal_strength():
     assert parse_signal_strength('-65dBm') == '-65'
     assert parse_signal_strength('-72') == '-72'
     assert parse_signal_strength(None) == ''
+
+
+def test_parse_uptime_seconds():
+    assert parse_uptime_seconds('45s') == 45
+    assert parse_uptime_seconds('3h15m2s') == 11702
+    assert parse_uptime_seconds('1d2h3m4s') == 93784
+    assert parse_uptime_seconds('1w2d3h4m5s') == 788645
+    assert parse_uptime_seconds('4s830ms') == 4
+
+
+def test_parse_uptime_seconds_invalid():
+    assert parse_uptime_seconds(None) is None
+    assert parse_uptime_seconds('') is None
+    assert parse_uptime_seconds('02:03:04') is None
+    assert parse_uptime_seconds('1d 2h') is None
+    assert parse_uptime_seconds('abc') is None
+
+
+def test_parse_rate_bps():
+    assert parse_rate_bps('866.6Mbps-80MHz/2S/SGI') == 866600000
+    assert parse_rate_bps('1.2Gbps-160MHz/2S/SGI') == 1200000000
+    assert parse_rate_bps('144.4Mbps') == 144400000
+    assert parse_rate_bps('6Mbps') == 6000000
+    assert parse_rate_bps('54kbps') == 54000
+    assert parse_rate_bps('866000000') == 866000000
+
+
+def test_parse_rate_bps_invalid():
+    assert parse_rate_bps(None) is None
+    assert parse_rate_bps('') is None
+    assert parse_rate_bps('unknown') is None
+    assert parse_rate_bps('-80MHz') is None
+    assert parse_rate_bps('Mbps') is None


### PR DESCRIPTION
`mktxp_wlan_clients_devices_info` and `mktxp_capsman_clients_devices_info` carried `uptime`, `rx_signal`, `tx_rate` and `rx_rate` as labels. These change on nearly every scrape, so each connected station produced a new time series per scrape (120 stations → ~170k series/day). Prometheus labels must be identity; changing values belong in the sample value. Same class of issue as #288 (active users login time).

## Changes

- Info metrics keep only labels that are stable for the lifetime of a registration: `dhcp_name`, `dhcp_address`, `ssid`, `interface`, `mac_address`, `band`.
- The removed values are exported as per-client gauges keyed like the existing `*_clients_signal_strength` gauge (`dhcp_name`, `mac_address`):
  - `mktxp_{wlan,capsman}_clients_uptime_seconds`
  - `mktxp_{wlan,capsman}_clients_tx_rate_bps`
  - `mktxp_{wlan,capsman}_clients_rx_rate_bps`
  
  `rx_signal` is already covered by `*_clients_signal_strength`, so no new gauge for it.
- New strict parsers `parse_uptime_seconds()` / `parse_rate_bps()` in `mktxp/utils/units.py`. A value that cannot be parsed is logged and its sample omitted; the rest of the scrape is unaffected. The raw values are still reformatted by `augment_record()` for the diag CLI tables, which are unchanged.
- Docs: new "Wireless Client Metrics" section in `docs/exporter.md` with the metric table and an example join query.

## Breaking change

Dashboards that read `uptime`, `rx_signal`, `tx_rate` or `rx_rate` from the `*_clients_devices_info` labels need to join the new gauges on `mac_address` instead, e.g.

```promql
mktxp_wlan_clients_tx_rate_bps * on (routerboard_name, mac_address) group_left (ssid, band) mktxp_wlan_clients_devices_info
```

## Testing

- Unit tests for the parsers (valid and invalid inputs), the enrichment helper, and both collectors (metric names, label sets, dropped samples).
- Live exporter run against RouterOS 7.23.1 (`wifi-qcom`, 56 stations): all clients parsed with no warnings, `*_clients_devices_info` series identical across two scrapes 60 s apart while the uptime/rate gauges updated in place.
- The legacy `wireless` package path is covered by unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
